### PR TITLE
Switch to crossbeam-channel subcrate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-crossbeam = "0.7"
+crossbeam-channel = "0.5"
 log = "0.4"
 parking_lot = "0.11"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@
 //! ```
 //!
 
-use crossbeam::channel::{self, select, Receiver, SendError, Sender, TrySendError};
+use crossbeam_channel::{self as channel, select, Receiver, SendError, Sender, TrySendError};
 use log::*;
 use parking_lot::{Mutex, RwLock};
 use std::{fmt, ops::Deref, sync::Arc, thread, time::Duration};


### PR DESCRIPTION
It's minor, but the compilation time is reduced from 6.2 to 5.1 seconds on my 2020 macbook pro. On comparison, actix took 20.1s (after warming up the cash and excluding fetch.)