### PR TITLE
relax constraints on Send in System and SpawnBuilder

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,7 @@ pub struct SpawnBuilder<'a, A: Actor, F: FnOnce() -> A> {
     system: &'a mut System,
     capacity: Option<usize>,
     addr: Option<Addr<A>>,
-    factory: Box<F>,
+    factory: F,
 }
 
 impl<'a, A: 'static + Actor, F: FnOnce() -> A> SpawnBuilder<'a, A, F> {
@@ -265,7 +265,7 @@ impl System {
         A: Actor + 'static,
         F: FnOnce() -> A + Send + 'static,
     {
-        SpawnBuilder { system: self, capacity: None, addr: None, factory: Box::new(factory) }
+        SpawnBuilder { system: self, capacity: None, addr: None, factory }
     }
 
     /// Spawn a normal [`Actor`] in the system, returning its address when successful.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,7 +260,7 @@ impl System {
     /// created on its own thread instead of the calling thread.
     /// Returns a [`SpawnBuilder`] which can be used to customize the
     /// spawning of the actor.
-    pub fn prepare_fn<A, F>(&mut self, factory: F) -> SpawnBuilder<A, impl FnOnce() -> A>
+    pub fn prepare_fn<A, F>(&mut self, factory: F) -> SpawnBuilder<A, F>
     where
         A: Actor + 'static,
         F: FnOnce() -> A + Send + 'static,


### PR DESCRIPTION
On integrating the new actor system with tonari's main codebase, the type system showed more restrictiveness than was necessary, making it impossible to run an `Actor` on the main thread if `Actor` didn't implement `Send` (which of course is unnecessary if not being spawned on a separate thread).