### PR TITLE
chore: remove one boxing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,7 +252,7 @@ impl System {
     where
         A: Actor + 'static,
     {
-        SpawnBuilder { system: self, capacity: None, addr: None, factory: Box::new(move || actor) }
+        SpawnBuilder { system: self, capacity: None, addr: None, factory: move || actor }
     }
 
     /// Similar to `prepare`, but an actor factory is passed instead


### PR DESCRIPTION
Kinda interesting that this worked before. Apparently, Box<Fn*> implements Fn*:
https://doc.rust-lang.org/std/boxed/struct.Box.html#impl-FnOnce%3CArgs%3E