### PR TITLE
Simple Timer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ keywords = ["actor", "threads"]
 crossbeam-channel = "0.5"
 log = "0.4"
 parking_lot = "0.11"
+spin_sleep = "1"
+uuid = { version = "0.8", features = ["v4"] }
 
 [dev-dependencies]
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tonari-actor"
 description = "A minimalist actor framework aiming for high performance and simplicity."
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Jake McGinty <me@jake.su>", "Matěj Laitl <matej@laitl.com>", "Ryo Kawaguchi <ryo@kawagu.ch>", "Brian Schwind <brianmschwind@gmail.com>"]
 license = "MIT"
 edition = "2018"

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -22,7 +22,7 @@ impl Actor for ChainLink {
         if message > 0 {
             self.next.send(message - 1).unwrap();
         } else {
-            context.system_handle.shutdown().unwrap();
+            context.shutdown().unwrap();
         }
 
         Ok(())

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -16,7 +16,7 @@ impl Actor for ChainLink {
 
     fn handle(
         &mut self,
-        context: &Context<Self>,
+        context: &mut Context<Self>,
         message: Self::Message,
     ) -> Result<(), Self::Error> {
         if message > 0 {

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -83,7 +83,11 @@ impl Actor for Input {
         "Input"
     }
 
-    fn handle(&mut self, context: &Context<Self>, _message: ReadNext) -> Result<(), Self::Error> {
+    fn handle(
+        &mut self,
+        context: &mut Context<Self>,
+        _message: ReadNext,
+    ) -> Result<(), Self::Error> {
         // Read data from stdin and decode into correct format.
         let mut bytes = [0u8; CHUNK_SAMPLES * SAMPLE_BYTES];
         stdin().read_exact(&mut bytes)?;
@@ -114,7 +118,7 @@ impl Actor for Output {
         "Output"
     }
 
-    fn handle(&mut self, _context: &Context<Self>, message: Chunk) -> Result<(), Self::Error> {
+    fn handle(&mut self, _context: &mut Context<Self>, message: Chunk) -> Result<(), Self::Error> {
         let mut buffered_stdout = BufWriter::new(stdout());
         for sample in message.iter() {
             for bytes in sample.iter().map(|s| s.to_ne_bytes()) {
@@ -174,7 +178,7 @@ impl Actor for Mixer {
         "Mixer"
     }
 
-    fn handle(&mut self, _context: &Context<Self>, message: MixerInput) -> Result<(), Error> {
+    fn handle(&mut self, _context: &mut Context<Self>, message: MixerInput) -> Result<(), Error> {
         // Naive implementation that simply overwrites on overflow.
         match message {
             MixerInput::Dry(chunk) => self.dry_buffer = Some(chunk),
@@ -224,7 +228,7 @@ impl Actor for Delay {
         "Delay"
     }
 
-    fn handle(&mut self, _context: &Context<Self>, message: Chunk) -> Result<(), Error> {
+    fn handle(&mut self, _context: &mut Context<Self>, message: Chunk) -> Result<(), Error> {
         self.buffer[self.index] = message;
 
         // Advance index, reset to zero on overflow.
@@ -248,7 +252,7 @@ impl Actor for Damper {
         "Damper"
     }
 
-    fn handle(&mut self, _context: &Context<Self>, message: Chunk) -> Result<(), Error> {
+    fn handle(&mut self, _context: &mut Context<Self>, message: Chunk) -> Result<(), Error> {
         // Halve the signal.
         let chunk_slice: Arc<[Sample]> = message.iter().map(|s| [s[0] / 2, s[1] / 2]).collect();
         let chunk: Chunk = chunk_slice.try_into().expect("sample count is correct");

--- a/examples/media_pipeline.rs
+++ b/examples/media_pipeline.rs
@@ -46,7 +46,7 @@ mod actors {
             context: &mut Context<Self>,
             _msg: Self::Message,
         ) -> Result<(), Self::Error> {
-            context.system_handle.shutdown().expect("ShutdownActor failed to shutdown system");
+            context.shutdown().expect("ShutdownActor failed to shutdown system");
             Ok(())
         }
     }
@@ -414,7 +414,7 @@ mod actors {
                         println!(
                             "We've received 360 video frames, shutting down the actor system!"
                         );
-                        let _ = context.system_handle.shutdown();
+                        let _ = context.shutdown();
                     }
                 },
                 MediaFrame::Audio(_) => {

--- a/examples/media_pipeline.rs
+++ b/examples/media_pipeline.rs
@@ -43,7 +43,7 @@ mod actors {
 
         fn handle(
             &mut self,
-            context: &Context<Self>,
+            context: &mut Context<Self>,
             _msg: Self::Message,
         ) -> Result<(), Self::Error> {
             context.system_handle.shutdown().expect("ShutdownActor failed to shutdown system");
@@ -73,7 +73,7 @@ mod actors {
 
         fn handle(
             &mut self,
-            context: &Context<Self>,
+            context: &mut Context<Self>,
             message: Self::Message,
         ) -> Result<(), Self::Error> {
             match message {
@@ -111,7 +111,7 @@ mod actors {
 
         fn handle(
             &mut self,
-            _context: &Context<Self>,
+            _context: &mut Context<Self>,
             message: Self::Message,
         ) -> Result<(), Self::Error> {
             match message {
@@ -150,7 +150,7 @@ mod actors {
 
         fn handle(
             &mut self,
-            context: &Context<Self>,
+            context: &mut Context<Self>,
             message: Self::Message,
         ) -> Result<(), Self::Error> {
             match message {
@@ -189,7 +189,7 @@ mod actors {
 
         fn handle(
             &mut self,
-            _context: &Context<Self>,
+            _context: &mut Context<Self>,
             message: Self::Message,
         ) -> Result<(), Self::Error> {
             match message {
@@ -227,7 +227,7 @@ mod actors {
 
         fn handle(
             &mut self,
-            _context: &Context<Self>,
+            _context: &mut Context<Self>,
             message: Self::Message,
         ) -> Result<(), Self::Error> {
             // Add some fake packetization and network latency here
@@ -263,7 +263,7 @@ mod actors {
 
         fn handle(
             &mut self,
-            _context: &Context<Self>,
+            _context: &mut Context<Self>,
             message: Self::Message,
         ) -> Result<(), Self::Error> {
             match message {
@@ -299,7 +299,7 @@ mod actors {
 
         fn handle(
             &mut self,
-            _context: &Context<Self>,
+            _context: &mut Context<Self>,
             message: Self::Message,
         ) -> Result<(), Self::Error> {
             match message {
@@ -335,7 +335,7 @@ mod actors {
 
         fn handle(
             &mut self,
-            _context: &Context<Self>,
+            _context: &mut Context<Self>,
             message: Self::Message,
         ) -> Result<(), Self::Error> {
             match message {
@@ -369,7 +369,7 @@ mod actors {
 
         fn handle(
             &mut self,
-            _context: &Context<Self>,
+            _context: &mut Context<Self>,
             message: Self::Message,
         ) -> Result<(), Self::Error> {
             match message {
@@ -403,7 +403,7 @@ mod actors {
 
         fn handle(
             &mut self,
-            context: &Context<Self>,
+            context: &mut Context<Self>,
             message: Self::Message,
         ) -> Result<(), Self::Error> {
             match message {

--- a/examples/simple_timer.rs
+++ b/examples/simple_timer.rs
@@ -1,7 +1,7 @@
 use anyhow::Error;
 use env_logger::Env;
 use std::time::{Duration, Instant};
-use tonari_actor::{timer::TimerControlFlow, Actor, Context, System};
+use tonari_actor::{Actor, Context, System};
 
 #[derive(Debug)]
 enum TimerMessage {
@@ -28,22 +28,10 @@ impl Actor for TimerExampleActor {
     }
 
     fn started(&mut self, context: &mut Context<Self>) {
-        let myself = context.myself.clone();
+        context.send_once_to_self(Duration::from_millis(1500), TimerMessage::Once);
 
-        context.run_once(Duration::from_millis(1500), move |_| {
-            if let Err(e) = myself.send(TimerMessage::Once) {
-                println!("Error sending TimerMessage::Once message: {}", e);
-            }
-        });
-
-        let myself = context.myself.clone();
-
-        context.run_recurring(Duration::from_secs(0), Duration::from_secs(1), move |_| {
-            if let Err(e) = myself.send(TimerMessage::Periodic) {
-                println!("Error sending TimerMessage::Periodic message: {}", e);
-            }
-
-            TimerControlFlow::Continue
+        context.send_recurring_to_self(Duration::from_secs(0), Duration::from_secs(1), || {
+            TimerMessage::Periodic
         });
     }
 

--- a/examples/simple_timer.rs
+++ b/examples/simple_timer.rs
@@ -1,0 +1,69 @@
+use anyhow::Error;
+use env_logger::Env;
+use std::time::{Duration, Instant};
+use tonari_actor::{timer::TimerControlFlow, Actor, Context, System};
+
+#[derive(Debug)]
+enum TimerMessage {
+    Once,
+    Periodic,
+}
+
+struct TimerExampleActor {
+    started_at: Instant,
+}
+
+impl TimerExampleActor {
+    pub fn new() -> Self {
+        Self { started_at: Instant::now() }
+    }
+}
+
+impl Actor for TimerExampleActor {
+    type Error = Error;
+    type Message = TimerMessage;
+
+    fn name() -> &'static str {
+        "TimerExampleActor"
+    }
+
+    fn started(&mut self, context: &mut Context<Self>) {
+        let myself = context.myself.clone();
+
+        context.run_once(Duration::from_millis(1500), move |_| {
+            if let Err(e) = myself.send(TimerMessage::Once) {
+                println!("Error sending TimerMessage::Once message: {}", e);
+            }
+        });
+
+        let myself = context.myself.clone();
+
+        context.run_recurring(Duration::from_secs(0), Duration::from_secs(1), move |_| {
+            if let Err(e) = myself.send(TimerMessage::Periodic) {
+                println!("Error sending TimerMessage::Periodic message: {}", e);
+            }
+
+            TimerControlFlow::Continue
+        });
+    }
+
+    fn handle(
+        &mut self,
+        _context: &mut Context<Self>,
+        message: Self::Message,
+    ) -> Result<(), Self::Error> {
+        println!("Got a message: {:?} at {:?}", message, self.started_at.elapsed());
+        Ok(())
+    }
+}
+
+fn main() -> Result<(), Error> {
+    env_logger::Builder::from_env(Env::default().default_filter_or("debug")).init();
+
+    let mut system = System::new("Example Timer System");
+
+    let timer_actor = TimerExampleActor::new();
+    system.prepare(timer_actor).run_and_block()?;
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,7 @@ impl<A: Actor + ?Sized> Context<A> {
     where
         R: Actor + ?Sized,
     {
-        run_once(&mut self.timer, delay, move |_| {
+        self.timer.run_once(delay, move |_| {
             if let Err(e) = recipient.send(msg) {
                 warn!("Error in send_once_to: {}", e);
             }
@@ -251,7 +251,7 @@ impl<A: Actor + ?Sized> Context<A> {
         F: FnMut() -> R::Message + Send + 'static,
         R: Actor + ?Sized,
     {
-        run_recurring(&mut self.timer, delay, interval, move |_| {
+        self.timer.run_recurring(delay, interval, move |_| {
             if let Err(e) = recipient.send(msg_producer()) {
                 warn!("Error in send_recurring_to: {}", e);
             }
@@ -316,25 +316,6 @@ impl<'a, A: 'static + Actor, F: FnOnce() -> A + Send + 'static> SpawnBuilder<'a,
 
         self.system.spawn_fn_with_addr(factory, addr.clone()).map(move |_| addr)
     }
-}
-
-fn run_once<F>(timer: &mut TimerRef, delay: Duration, callback: F) -> ScheduleToken
-where
-    F: FnOnce(ScheduleToken) + Send + 'static,
-{
-    timer.run_once(delay, callback)
-}
-
-fn run_recurring<F>(
-    timer: &mut TimerRef,
-    delay: Duration,
-    interval: Duration,
-    callback: F,
-) -> ScheduleToken
-where
-    F: FnMut(ScheduleToken) + Send + 'static,
-{
-    timer.run_recurring(delay, interval, callback)
 }
 
 impl System {

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -97,6 +97,10 @@ impl TimerRef {
     pub fn cancel(&mut self, schedule_token: ScheduleToken) {
         let _ = self.thread_tx.send(ThreadMessage::Cancel(schedule_token));
     }
+
+    pub(crate) fn shutdown(&mut self) {
+        let _ = self.thread_tx.send(ThreadMessage::Shutdown);
+    }
 }
 
 impl TimerHandle {

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,0 +1,192 @@
+use crossbeam_channel::{Receiver, Sender};
+use std::{
+    thread::JoinHandle,
+    time::{Duration, Instant},
+};
+use uuid::Uuid;
+
+pub enum TimerType {
+    OneShot(Box<dyn FnOnce(ScheduleToken) + Send + 'static>),
+    Recurring(Duration, Box<dyn FnMut(ScheduleToken) -> TimerControlFlow + Send + 'static>),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ScheduleToken {
+    uuid: Uuid,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum TimerControlFlow {
+    Continue,
+    Cancel,
+}
+
+impl ScheduleToken {
+    fn new() -> Self {
+        let id = Uuid::new_v4();
+
+        Self { uuid: id }
+    }
+}
+
+enum ThreadMessage {
+    Shutdown,
+    Cancel(ScheduleToken),
+    Run(TimerEntry),
+}
+
+struct TimerEntry {
+    schedule_token: ScheduleToken,
+    scheduled_at: Instant,
+    timer_type: TimerType,
+}
+
+#[derive(Debug)]
+pub struct TimerHandle {
+    join_handle: JoinHandle<()>,
+    timer_ref: TimerRef,
+}
+
+#[derive(Debug, Clone)]
+pub struct TimerRef {
+    thread_tx: Sender<ThreadMessage>,
+}
+
+impl TimerRef {
+    pub fn run_once<F>(&mut self, delay: Duration, callback: F) -> ScheduleToken
+    where
+        F: FnOnce(ScheduleToken) + Send + 'static,
+    {
+        let now = Instant::now();
+        let schedule_token = ScheduleToken::new();
+
+        let timer_entry = TimerEntry {
+            schedule_token,
+            scheduled_at: now + delay,
+            timer_type: TimerType::OneShot(Box::new(callback)),
+        };
+
+        let _ = self.thread_tx.send(ThreadMessage::Run(timer_entry));
+
+        schedule_token
+    }
+
+    pub fn run_recurring<F>(
+        &mut self,
+        delay: Duration,
+        interval: Duration,
+        callback: F,
+    ) -> ScheduleToken
+    where
+        F: FnMut(ScheduleToken) -> TimerControlFlow + Send + 'static,
+    {
+        let now = Instant::now();
+        let schedule_token = ScheduleToken::new();
+
+        let timer_entry = TimerEntry {
+            schedule_token,
+            scheduled_at: now + delay,
+            timer_type: TimerType::Recurring(interval, Box::new(callback)),
+        };
+
+        let _ = self.thread_tx.send(ThreadMessage::Run(timer_entry));
+
+        schedule_token
+    }
+
+    pub fn cancel(&mut self, schedule_token: ScheduleToken) {
+        let _ = self.thread_tx.send(ThreadMessage::Cancel(schedule_token));
+    }
+}
+
+impl TimerHandle {
+    pub fn new(timer_resolution: Duration) -> Self {
+        let (thread_tx, thread_rx) = crossbeam_channel::unbounded();
+
+        let mut timer_thread = TimerThread::new(timer_resolution, thread_rx);
+
+        let join_handle = std::thread::spawn(move || {
+            timer_thread.run();
+        });
+
+        let timer_ref = TimerRef { thread_tx };
+
+        Self { join_handle, timer_ref }
+    }
+
+    pub fn timer_ref(&self) -> TimerRef {
+        self.timer_ref.clone()
+    }
+
+    pub fn shutdown(self) {
+        let _ = self.timer_ref.thread_tx.send(ThreadMessage::Shutdown);
+        let _ = self.join_handle.join();
+    }
+}
+
+pub struct TimerThread {
+    timer_resolution: Duration,
+    thread_rx: Receiver<ThreadMessage>,
+    entries: Vec<TimerEntry>,
+}
+
+impl TimerThread {
+    fn new(timer_resolution: Duration, thread_rx: Receiver<ThreadMessage>) -> Self {
+        Self { timer_resolution, thread_rx, entries: Vec::new() }
+    }
+
+    fn run(&mut self) {
+        loop {
+            // Try to timer entries or control messages from the channel.
+            if let Ok(msg) = self.thread_rx.try_recv() {
+                match msg {
+                    ThreadMessage::Shutdown => {
+                        break;
+                    },
+                    ThreadMessage::Cancel(schedule_token) => {
+                        if let Some(pos) =
+                            self.entries.iter().position(|e| e.schedule_token == schedule_token)
+                        {
+                            self.entries.swap_remove(pos);
+                        }
+                    },
+                    ThreadMessage::Run(entry) => {
+                        self.entries.push(entry);
+                    },
+                }
+            }
+
+            // Expire and run all timers
+            let now = Instant::now();
+
+            for i in (0..self.entries.len()).rev() {
+                if now > self.entries[i].scheduled_at {
+                    let entry = self.entries.swap_remove(i);
+                    let schedule_token = entry.schedule_token;
+
+                    match entry.timer_type {
+                        TimerType::OneShot(closure) => {
+                            closure(schedule_token);
+                        },
+                        TimerType::Recurring(interval, mut closure) => {
+                            match closure(schedule_token) {
+                                TimerControlFlow::Continue => {
+                                    let new_entry = TimerEntry {
+                                        schedule_token,
+                                        scheduled_at: entry.scheduled_at + interval,
+                                        timer_type: TimerType::Recurring(interval, closure),
+                                    };
+
+                                    self.entries.push(new_entry);
+                                },
+                                TimerControlFlow::Cancel => {},
+                            }
+                        },
+                    }
+                }
+            }
+
+            spin_sleep::sleep(self.timer_resolution);
+        }
+    }
+}

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -109,9 +109,12 @@ impl TimerHandle {
 
         let mut timer_thread = TimerThread::new(timer_resolution, thread_rx);
 
-        let join_handle = std::thread::spawn(move || {
-            timer_thread.run();
-        });
+        let join_handle = std::thread::Builder::new()
+            .name("TonariActorTimer".to_string())
+            .spawn(move || {
+                timer_thread.run();
+            })
+            .expect("Couldn't spawn tonari actor timer thread");
 
         let timer_ref = TimerRef { thread_tx };
 


### PR DESCRIPTION
From #14

This feels a lot simpler than using `hierarchical_hash_wheel_timer`.

It does the dumb thing which is to just keep a `Vec` of tasks and tick every millisecond (or a configurable timer resolution). It iterates over each task and runs if it has expired, and reschedules it if it's a recurring task.

CPU usage is noticeably lower compared to `hierarchical_hash_wheel_timer` but it likely doesn't scale as well with lots and lots of timers in comparison. 