### PR TITLE
Context: change myself field from Addr<A> to Recipient<M>

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -16,7 +16,7 @@ impl Actor for ChainLink {
 
     fn handle(
         &mut self,
-        context: &mut Context<Self>,
+        context: &mut Context<Self::Message>,
         message: Self::Message,
     ) -> Result<(), Self::Error> {
         if message > 0 {

--- a/examples/actor_wrapping.rs
+++ b/examples/actor_wrapping.rs
@@ -1,0 +1,78 @@
+use anyhow::Error;
+use env_logger::Env;
+use log::debug;
+use std::time::{Duration, Instant};
+use tonari_actor::{Actor, Context, System};
+
+/// An actor that wraps any other actor and adds some debug logging around its calls.
+struct LoggingAdapter<A> {
+    inner: A,
+}
+
+impl<A: Actor> Actor for LoggingAdapter<A> {
+    type Error = A::Error;
+    type Message = A::Message;
+
+    fn handle(
+        &mut self,
+        context: &mut Context<Self::Message>,
+        message: Self::Message,
+    ) -> Result<(), Self::Error> {
+        debug!("LoggingAdapter: handle()");
+        self.inner.handle(context, message)
+    }
+
+    fn name() -> &'static str {
+        A::name()
+    }
+
+    fn started(&mut self, context: &mut Context<Self::Message>) {
+        debug!("LoggingAdapter: started()");
+        self.inner.started(context)
+    }
+
+    fn stopped(&mut self, context: &mut Context<Self::Message>) {
+        debug!("LoggingAdapter: stopped()");
+        self.inner.stopped(context)
+    }
+
+    fn deadline_passed(&mut self, context: &mut Context<Self::Message>, deadline: Instant) {
+        debug!("LoggingAdapter: deadline_passed()");
+        self.inner.deadline_passed(context, deadline)
+    }
+}
+
+struct TestActor {}
+
+impl Actor for TestActor {
+    type Error = Error;
+    type Message = String;
+
+    fn handle(&mut self, context: &mut Context<String>, message: String) -> Result<(), Error> {
+        println!("Got a message: {}. Shuting down.", message);
+        context.system_handle.shutdown().map_err(Error::from)
+    }
+
+    fn name() -> &'static str {
+        "TestActor"
+    }
+
+    fn started(&mut self, context: &mut Context<String>) {
+        context.set_timeout(Some(Duration::from_millis(100)))
+    }
+
+    fn deadline_passed(&mut self, context: &mut Context<String>, deadline: Instant) {
+        context.myself.send(format!("deadline was {:?}", deadline)).unwrap();
+    }
+}
+
+fn main() -> Result<(), Error> {
+    env_logger::Builder::from_env(Env::default().default_filter_or("debug")).init();
+
+    let mut system = System::new("Actor Wrapping Example");
+
+    let actor = LoggingAdapter { inner: TestActor {} };
+    system.prepare(actor).run_and_block()?;
+
+    Ok(())
+}

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -85,7 +85,7 @@ impl Actor for Input {
 
     fn handle(
         &mut self,
-        context: &mut Context<Self>,
+        context: &mut Context<ReadNext>,
         _message: ReadNext,
     ) -> Result<(), Self::Error> {
         // Read data from stdin and decode into correct format.
@@ -118,7 +118,7 @@ impl Actor for Output {
         "Output"
     }
 
-    fn handle(&mut self, _context: &mut Context<Self>, message: Chunk) -> Result<(), Self::Error> {
+    fn handle(&mut self, _context: &mut Context<Chunk>, message: Chunk) -> Result<(), Self::Error> {
         let mut buffered_stdout = BufWriter::new(stdout());
         for sample in message.iter() {
             for bytes in sample.iter().map(|s| s.to_ne_bytes()) {
@@ -178,7 +178,11 @@ impl Actor for Mixer {
         "Mixer"
     }
 
-    fn handle(&mut self, _context: &mut Context<Self>, message: MixerInput) -> Result<(), Error> {
+    fn handle(
+        &mut self,
+        _context: &mut Context<MixerInput>,
+        message: MixerInput,
+    ) -> Result<(), Error> {
         // Naive implementation that simply overwrites on overflow.
         match message {
             MixerInput::Dry(chunk) => self.dry_buffer = Some(chunk),
@@ -228,7 +232,7 @@ impl Actor for Delay {
         "Delay"
     }
 
-    fn handle(&mut self, _context: &mut Context<Self>, message: Chunk) -> Result<(), Error> {
+    fn handle(&mut self, _context: &mut Context<Chunk>, message: Chunk) -> Result<(), Error> {
         self.buffer[self.index] = message;
 
         // Advance index, reset to zero on overflow.
@@ -252,7 +256,7 @@ impl Actor for Damper {
         "Damper"
     }
 
-    fn handle(&mut self, _context: &mut Context<Self>, message: Chunk) -> Result<(), Error> {
+    fn handle(&mut self, _context: &mut Context<Chunk>, message: Chunk) -> Result<(), Error> {
         // Halve the signal.
         let chunk_slice: Arc<[Sample]> = message.iter().map(|s| [s[0] / 2, s[1] / 2]).collect();
         let chunk: Chunk = chunk_slice.try_into().expect("sample count is correct");

--- a/examples/media_pipeline.rs
+++ b/examples/media_pipeline.rs
@@ -43,7 +43,7 @@ mod actors {
 
         fn handle(
             &mut self,
-            context: &mut Context<Self>,
+            context: &mut Context<Self::Message>,
             _msg: Self::Message,
         ) -> Result<(), Self::Error> {
             context.system_handle.shutdown().expect("ShutdownActor failed to shutdown system");
@@ -73,7 +73,7 @@ mod actors {
 
         fn handle(
             &mut self,
-            context: &mut Context<Self>,
+            context: &mut Context<Self::Message>,
             message: Self::Message,
         ) -> Result<(), Self::Error> {
             match message {
@@ -111,7 +111,7 @@ mod actors {
 
         fn handle(
             &mut self,
-            _context: &mut Context<Self>,
+            _context: &mut Context<Self::Message>,
             message: Self::Message,
         ) -> Result<(), Self::Error> {
             match message {
@@ -150,7 +150,7 @@ mod actors {
 
         fn handle(
             &mut self,
-            context: &mut Context<Self>,
+            context: &mut Context<Self::Message>,
             message: Self::Message,
         ) -> Result<(), Self::Error> {
             match message {
@@ -189,7 +189,7 @@ mod actors {
 
         fn handle(
             &mut self,
-            _context: &mut Context<Self>,
+            _context: &mut Context<Self::Message>,
             message: Self::Message,
         ) -> Result<(), Self::Error> {
             match message {
@@ -227,7 +227,7 @@ mod actors {
 
         fn handle(
             &mut self,
-            _context: &mut Context<Self>,
+            _context: &mut Context<Self::Message>,
             message: Self::Message,
         ) -> Result<(), Self::Error> {
             // Add some fake packetization and network latency here
@@ -263,7 +263,7 @@ mod actors {
 
         fn handle(
             &mut self,
-            _context: &mut Context<Self>,
+            _context: &mut Context<Self::Message>,
             message: Self::Message,
         ) -> Result<(), Self::Error> {
             match message {
@@ -299,7 +299,7 @@ mod actors {
 
         fn handle(
             &mut self,
-            _context: &mut Context<Self>,
+            _context: &mut Context<Self::Message>,
             message: Self::Message,
         ) -> Result<(), Self::Error> {
             match message {
@@ -335,7 +335,7 @@ mod actors {
 
         fn handle(
             &mut self,
-            _context: &mut Context<Self>,
+            _context: &mut Context<Self::Message>,
             message: Self::Message,
         ) -> Result<(), Self::Error> {
             match message {
@@ -369,7 +369,7 @@ mod actors {
 
         fn handle(
             &mut self,
-            _context: &mut Context<Self>,
+            _context: &mut Context<Self::Message>,
             message: Self::Message,
         ) -> Result<(), Self::Error> {
             match message {
@@ -403,7 +403,7 @@ mod actors {
 
         fn handle(
             &mut self,
-            context: &mut Context<Self>,
+            context: &mut Context<Self::Message>,
             message: Self::Message,
         ) -> Result<(), Self::Error> {
             match message {

--- a/examples/simple_timer.rs
+++ b/examples/simple_timer.rs
@@ -26,20 +26,20 @@ impl Actor for TimerExampleActor {
         "TimerExampleActor"
     }
 
-    fn started(&mut self, context: &mut Context<Self>) {
+    fn started(&mut self, context: &mut Context<Self::Message>) {
         context.set_deadline(Some(self.started_at + Duration::from_millis(1500)));
     }
 
     fn handle(
         &mut self,
-        _context: &mut Context<Self>,
+        _context: &mut Context<Self::Message>,
         message: Self::Message,
     ) -> Result<(), Self::Error> {
         println!("Got a message: {:?} at {:?}", message, self.started_at.elapsed());
         Ok(())
     }
 
-    fn deadline_passed(&mut self, context: &mut Context<Self>, deadline: Instant) {
+    fn deadline_passed(&mut self, context: &mut Context<Self::Message>, deadline: Instant) {
         context.myself.send(TimerMessage::Periodic).unwrap();
         context.set_deadline(Some(deadline + Duration::from_secs(1)));
     }


### PR DESCRIPTION
This makes whole Context parametrised by M (message), rather than A: Actor.
As a result, Context is more flexible to pass on, which facilitates creation
of Actor wrappers.

This changes the signature of the Actor trait methods, which breaks the API,
though required edits should be mostly mechanical. The field `myself` was
arguably used most for sending messages to oneself, which already went
through a `Deref` to `Recipient`.

One piece of functionality was lost on Context: the `Addr::recipient()`
method which can produce a "converting" recipient.
`recipient()` can be moved from `Addr` to `Recipient` to preserve it.
Do you think it is needed?