### PR TITLE
Add Timed actor wrapper + friends for delayed/recurring messages

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -17,7 +17,7 @@ impl Actor for ChainLink {
 
     fn handle(
         &mut self,
-        context: &mut Context<Self::Message>,
+        context: &mut Self::Context,
         message: Self::Message,
     ) -> Result<(), Self::Error> {
         if message > 0 {

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -7,6 +7,7 @@ struct ChainLink {
 }
 
 impl Actor for ChainLink {
+    type Context = Context<Self::Message>;
     type Error = ();
     type Message = u64;
 

--- a/examples/actor_wrapping.rs
+++ b/examples/actor_wrapping.rs
@@ -37,7 +37,11 @@ impl<A: Actor> Actor for LoggingAdapter<A> {
         self.inner.stopped(context)
     }
 
-    fn deadline_passed(&mut self, context: &mut Self::Context, deadline: Instant) {
+    fn deadline_passed(
+        &mut self,
+        context: &mut Self::Context,
+        deadline: Instant,
+    ) -> Result<(), Self::Error> {
         debug!("LoggingAdapter: deadline_passed()");
         self.inner.deadline_passed(context, deadline)
     }
@@ -63,8 +67,12 @@ impl Actor for TestActor {
         context.set_timeout(Some(Duration::from_millis(100)))
     }
 
-    fn deadline_passed(&mut self, context: &mut Self::Context, deadline: Instant) {
-        context.myself.send(format!("deadline was {:?}", deadline)).unwrap();
+    fn deadline_passed(
+        &mut self,
+        context: &mut Self::Context,
+        deadline: Instant,
+    ) -> Result<(), Error> {
+        context.myself.send(format!("deadline was {:?}", deadline)).map_err(Error::from)
     }
 }
 

--- a/examples/actor_wrapping.rs
+++ b/examples/actor_wrapping.rs
@@ -50,7 +50,7 @@ impl Actor for TestActor {
     type Error = Error;
     type Message = String;
 
-    fn handle(&mut self, context: &mut Context<String>, message: String) -> Result<(), Error> {
+    fn handle(&mut self, context: &mut Self::Context, message: String) -> Result<(), Error> {
         println!("Got a message: {}. Shuting down.", message);
         context.system_handle.shutdown().map_err(Error::from)
     }
@@ -59,11 +59,11 @@ impl Actor for TestActor {
         "TestActor"
     }
 
-    fn started(&mut self, context: &mut Context<String>) {
+    fn started(&mut self, context: &mut Self::Context) {
         context.set_timeout(Some(Duration::from_millis(100)))
     }
 
-    fn deadline_passed(&mut self, context: &mut Context<String>, deadline: Instant) {
+    fn deadline_passed(&mut self, context: &mut Self::Context, deadline: Instant) {
         context.myself.send(format!("deadline was {:?}", deadline)).unwrap();
     }
 }

--- a/examples/actor_wrapping.rs
+++ b/examples/actor_wrapping.rs
@@ -10,12 +10,13 @@ struct LoggingAdapter<A> {
 }
 
 impl<A: Actor> Actor for LoggingAdapter<A> {
+    type Context = A::Context;
     type Error = A::Error;
     type Message = A::Message;
 
     fn handle(
         &mut self,
-        context: &mut Context<Self::Message>,
+        context: &mut Self::Context,
         message: Self::Message,
     ) -> Result<(), Self::Error> {
         debug!("LoggingAdapter: handle()");
@@ -26,17 +27,17 @@ impl<A: Actor> Actor for LoggingAdapter<A> {
         A::name()
     }
 
-    fn started(&mut self, context: &mut Context<Self::Message>) {
+    fn started(&mut self, context: &mut Self::Context) {
         debug!("LoggingAdapter: started()");
         self.inner.started(context)
     }
 
-    fn stopped(&mut self, context: &mut Context<Self::Message>) {
+    fn stopped(&mut self, context: &mut Self::Context) {
         debug!("LoggingAdapter: stopped()");
         self.inner.stopped(context)
     }
 
-    fn deadline_passed(&mut self, context: &mut Context<Self::Message>, deadline: Instant) {
+    fn deadline_passed(&mut self, context: &mut Self::Context, deadline: Instant) {
         debug!("LoggingAdapter: deadline_passed()");
         self.inner.deadline_passed(context, deadline)
     }
@@ -45,6 +46,7 @@ impl<A: Actor> Actor for LoggingAdapter<A> {
 struct TestActor {}
 
 impl Actor for TestActor {
+    type Context = Context<Self::Message>;
     type Error = Error;
     type Message = String;
 

--- a/examples/delay_actor.rs
+++ b/examples/delay_actor.rs
@@ -72,6 +72,7 @@ impl DelayActor {
 }
 
 impl Actor for DelayActor {
+    type Context = Context<Self::Message>;
     type Error = Error;
     type Message = DelayedMessage;
 
@@ -108,6 +109,7 @@ struct FinalConsumer {
 }
 
 impl Actor for FinalConsumer {
+    type Context = Context<Self::Message>;
     type Error = Error;
     type Message = String;
 

--- a/examples/delay_actor.rs
+++ b/examples/delay_actor.rs
@@ -1,117 +1,17 @@
 use anyhow::Error;
 use env_logger::Env;
-use std::{
-    cmp::Ordering,
-    collections::BinaryHeap,
-    time::{Duration, Instant},
+use std::time::{Duration, Instant};
+use tonari_actor::{
+    timed::{RecipientExt, Timed, TimedContext},
+    Actor, System,
 };
-use tonari_actor::{Actor, Context, Recipient, SendError, System};
-
-/// Something that can be sent. A message with a recipient.
-trait Envelope {
-    fn send(self: Box<Self>) -> Result<(), SendError>;
-}
-
-impl<M> Envelope for (Recipient<M>, M) {
-    fn send(self: Box<Self>) -> Result<(), SendError> {
-        self.0.send(self.1)
-    }
-}
-
-struct DelayedMessage {
-    fire_at: Instant,
-    message: Box<dyn Envelope + Send>,
-}
-
-impl DelayedMessage {
-    fn new<M: Send + 'static>(fire_at: Instant, recipient: &Recipient<M>, message: M) -> Self {
-        Self { fire_at, message: Box::new((recipient.clone(), message)) }
-    }
-}
-
-impl PartialEq for DelayedMessage {
-    fn eq(&self, other: &Self) -> bool {
-        self.fire_at == other.fire_at
-    }
-}
-
-// We cannot derive because that would add too strict bounds.
-impl Eq for DelayedMessage {}
-
-impl PartialOrd for DelayedMessage {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        // Reverse because [BinaryHeap] is a *max* heap, but we want pop() to return lowest `fire_at`.
-        Some(self.fire_at.cmp(&other.fire_at).reverse())
-    }
-}
-
-impl Ord for DelayedMessage {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.partial_cmp(other).expect("we can always compare")
-    }
-}
-
-/// A simple actor to send messages with delay. Possible extensions:
-/// * Support recurring messages.
-/// * Support cancellation.
-/// * Implement some `DelayActorExt` trait on `Recipient<DelayActor>` for caller convenience.
-struct DelayActor {
-    queue: BinaryHeap<DelayedMessage>,
-}
-
-impl DelayActor {
-    fn new() -> Self {
-        Self { queue: Default::default() }
-    }
-
-    fn schedule_timeout(&self, context: &mut Context<DelayedMessage>) {
-        // Schedule next timeout if the queue is not empty.
-        context.set_deadline(self.queue.peek().map(|earliest| earliest.fire_at));
-    }
-}
-
-impl Actor for DelayActor {
-    type Context = Context<Self::Message>;
-    type Error = Error;
-    type Message = DelayedMessage;
-
-    fn name() -> &'static str {
-        "DelayActor"
-    }
-
-    fn handle(
-        &mut self,
-        context: &mut Self::Context,
-        message: Self::Message,
-    ) -> Result<(), Self::Error> {
-        self.queue.push(message);
-        self.schedule_timeout(context);
-        Ok(())
-    }
-
-    fn deadline_passed(
-        &mut self,
-        context: &mut Self::Context,
-        _deadline: Instant,
-    ) -> Result<(), Error> {
-        // Send all messages that should have been sent by now.
-        let now = Instant::now();
-        while self.queue.peek().map(|m| m.fire_at <= now).unwrap_or(false) {
-            let message = self.queue.pop().expect("heap is non-empty, we have just peeked");
-            message.message.send()?;
-        }
-
-        self.schedule_timeout(context);
-        Ok(())
-    }
-}
 
 struct FinalConsumer {
     started_at: Instant,
 }
 
 impl Actor for FinalConsumer {
-    type Context = Context<Self::Message>;
+    type Context = TimedContext<Self::Message>;
     type Error = Error;
     type Message = String;
 
@@ -133,19 +33,19 @@ fn main() -> Result<(), Error> {
 
     let mut system = System::new("Example Timer System");
 
-    let delay_actor = system.spawn(DelayActor::new())?;
-
-    let consumer = system.spawn(FinalConsumer { started_at: Instant::now() })?.recipient();
+    let consumer =
+        system.spawn(Timed::new(FinalConsumer { started_at: Instant::now() }))?.recipient();
 
     let now = Instant::now();
-    delay_actor.send(DelayedMessage::new(now + Duration::from_secs(3), &consumer, "last"))?;
-    delay_actor.send(DelayedMessage::new(
-        now + Duration::from_secs(4),
-        &consumer,
-        "never received",
-    ))?;
-    delay_actor.send(DelayedMessage::new(now + Duration::from_secs(2), &consumer, "second"))?;
-    delay_actor.send(DelayedMessage::new(now + Duration::from_secs(1), &consumer, "first"))?;
+    consumer.send_recurring(
+        || "recurring".to_string(),
+        now + Duration::from_millis(500),
+        Duration::from_secs(1),
+    )?;
+    consumer.send_delayed("last".to_string(), Duration::from_secs(3))?;
+    consumer.send_delayed("never received".to_string(), Duration::from_secs(4))?;
+    consumer.send_timed("second".to_string(), now + Duration::from_secs(2))?;
+    consumer.send_timed("first".to_string(), now + Duration::from_secs(1))?;
 
     system.run()?;
 

--- a/examples/delay_actor.rs
+++ b/examples/delay_actor.rs
@@ -82,7 +82,7 @@ impl Actor for DelayActor {
 
     fn handle(
         &mut self,
-        context: &mut Context<Self::Message>,
+        context: &mut Self::Context,
         message: Self::Message,
     ) -> Result<(), Self::Error> {
         self.queue.push(message);
@@ -90,7 +90,7 @@ impl Actor for DelayActor {
         Ok(())
     }
 
-    fn deadline_passed(&mut self, context: &mut Context<Self::Message>, _deadline: Instant) {
+    fn deadline_passed(&mut self, context: &mut Self::Context, _deadline: Instant) {
         // Send all messages that should have been sent by now.
         let now = Instant::now();
         while self.queue.peek().map(|m| m.fire_at <= now).unwrap_or(false) {
@@ -117,7 +117,7 @@ impl Actor for FinalConsumer {
         "FinalConsumer"
     }
 
-    fn handle(&mut self, context: &mut Context<String>, message: String) -> Result<(), Error> {
+    fn handle(&mut self, context: &mut Self::Context, message: String) -> Result<(), Error> {
         println!("Got a message: {:?} at {:?}", message, self.started_at.elapsed());
         if message == "last" {
             context.system_handle.shutdown()?;

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -76,6 +76,7 @@ struct Input {
 }
 
 impl Actor for Input {
+    type Context = Context<Self::Message>;
     type Error = Error;
     type Message = ReadNext;
 
@@ -111,6 +112,7 @@ impl Actor for Input {
 struct Output;
 
 impl Actor for Output {
+    type Context = Context<Self::Message>;
     type Error = Error;
     type Message = Chunk;
 
@@ -171,6 +173,7 @@ impl Mixer {
 }
 
 impl Actor for Mixer {
+    type Context = Context<Self::Message>;
     type Error = Error;
     type Message = MixerInput;
 
@@ -225,6 +228,7 @@ impl Delay {
 }
 
 impl Actor for Delay {
+    type Context = Context<Self::Message>;
     type Error = Error;
     type Message = Chunk;
 
@@ -249,6 +253,7 @@ struct Damper {
 }
 
 impl Actor for Damper {
+    type Context = Context<Self::Message>;
     type Error = Error;
     type Message = Chunk;
 

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -86,7 +86,7 @@ impl Actor for Input {
 
     fn handle(
         &mut self,
-        context: &mut Context<ReadNext>,
+        context: &mut Self::Context,
         _message: ReadNext,
     ) -> Result<(), Self::Error> {
         // Read data from stdin and decode into correct format.
@@ -120,7 +120,7 @@ impl Actor for Output {
         "Output"
     }
 
-    fn handle(&mut self, _context: &mut Context<Chunk>, message: Chunk) -> Result<(), Self::Error> {
+    fn handle(&mut self, _context: &mut Self::Context, message: Chunk) -> Result<(), Self::Error> {
         let mut buffered_stdout = BufWriter::new(stdout());
         for sample in message.iter() {
             for bytes in sample.iter().map(|s| s.to_ne_bytes()) {
@@ -181,11 +181,7 @@ impl Actor for Mixer {
         "Mixer"
     }
 
-    fn handle(
-        &mut self,
-        _context: &mut Context<MixerInput>,
-        message: MixerInput,
-    ) -> Result<(), Error> {
+    fn handle(&mut self, _context: &mut Self::Context, message: MixerInput) -> Result<(), Error> {
         // Naive implementation that simply overwrites on overflow.
         match message {
             MixerInput::Dry(chunk) => self.dry_buffer = Some(chunk),
@@ -236,7 +232,7 @@ impl Actor for Delay {
         "Delay"
     }
 
-    fn handle(&mut self, _context: &mut Context<Chunk>, message: Chunk) -> Result<(), Error> {
+    fn handle(&mut self, _context: &mut Self::Context, message: Chunk) -> Result<(), Error> {
         self.buffer[self.index] = message;
 
         // Advance index, reset to zero on overflow.
@@ -261,7 +257,7 @@ impl Actor for Damper {
         "Damper"
     }
 
-    fn handle(&mut self, _context: &mut Context<Chunk>, message: Chunk) -> Result<(), Error> {
+    fn handle(&mut self, _context: &mut Self::Context, message: Chunk) -> Result<(), Error> {
         // Halve the signal.
         let chunk_slice: Arc<[Sample]> = message.iter().map(|s| [s[0] / 2, s[1] / 2]).collect();
         let chunk: Chunk = chunk_slice.try_into().expect("sample count is correct");

--- a/examples/media_pipeline.rs
+++ b/examples/media_pipeline.rs
@@ -34,6 +34,7 @@ mod actors {
     pub struct ShutdownActor;
 
     impl Actor for ShutdownActor {
+        type Context = Context<Self::Message>;
         type Error = Error;
         type Message = ();
 
@@ -64,6 +65,7 @@ mod actors {
     }
 
     impl Actor for VideoCaptureActor {
+        type Context = Context<Self::Message>;
         type Error = Error;
         type Message = VideoCaptureMessage;
 
@@ -102,6 +104,7 @@ mod actors {
     }
 
     impl Actor for VideoEncodeActor {
+        type Context = Context<Self::Message>;
         type Error = Error;
         type Message = MediaFrame;
 
@@ -141,6 +144,7 @@ mod actors {
     }
 
     impl Actor for AudioCaptureActor {
+        type Context = Context<Self::Message>;
         type Error = Error;
         type Message = AudioCaptureMessage;
 
@@ -180,6 +184,7 @@ mod actors {
     }
 
     impl Actor for AudioEncodeActor {
+        type Context = Context<Self::Message>;
         type Error = Error;
         type Message = MediaFrame;
 
@@ -218,6 +223,7 @@ mod actors {
     }
 
     impl Actor for NetworkSenderActor {
+        type Context = Context<Self::Message>;
         type Error = Error;
         type Message = EncodedMediaFrame;
 
@@ -254,6 +260,7 @@ mod actors {
     }
 
     impl Actor for NetworkReceiverActor {
+        type Context = Context<Self::Message>;
         type Error = Error;
         type Message = EncodedMediaFrame;
 
@@ -290,6 +297,7 @@ mod actors {
     }
 
     impl Actor for VideoDecodeActor {
+        type Context = Context<Self::Message>;
         type Error = Error;
         type Message = EncodedMediaFrame;
 
@@ -326,6 +334,7 @@ mod actors {
     }
 
     impl Actor for AudioDecodeActor {
+        type Context = Context<Self::Message>;
         type Error = Error;
         type Message = EncodedMediaFrame;
 
@@ -360,6 +369,7 @@ mod actors {
     }
 
     impl Actor for AudioPlaybackActor {
+        type Context = Context<Self::Message>;
         type Error = Error;
         type Message = MediaFrame;
 
@@ -394,6 +404,7 @@ mod actors {
     }
 
     impl Actor for VideoDisplayActor {
+        type Context = Context<Self::Message>;
         type Error = Error;
         type Message = MediaFrame;
 

--- a/examples/media_pipeline.rs
+++ b/examples/media_pipeline.rs
@@ -44,7 +44,7 @@ mod actors {
 
         fn handle(
             &mut self,
-            context: &mut Context<Self::Message>,
+            context: &mut Self::Context,
             _msg: Self::Message,
         ) -> Result<(), Self::Error> {
             context.system_handle.shutdown().expect("ShutdownActor failed to shutdown system");
@@ -75,7 +75,7 @@ mod actors {
 
         fn handle(
             &mut self,
-            context: &mut Context<Self::Message>,
+            context: &mut Self::Context,
             message: Self::Message,
         ) -> Result<(), Self::Error> {
             match message {
@@ -114,7 +114,7 @@ mod actors {
 
         fn handle(
             &mut self,
-            _context: &mut Context<Self::Message>,
+            _context: &mut Self::Context,
             message: Self::Message,
         ) -> Result<(), Self::Error> {
             match message {
@@ -154,7 +154,7 @@ mod actors {
 
         fn handle(
             &mut self,
-            context: &mut Context<Self::Message>,
+            context: &mut Self::Context,
             message: Self::Message,
         ) -> Result<(), Self::Error> {
             match message {
@@ -194,7 +194,7 @@ mod actors {
 
         fn handle(
             &mut self,
-            _context: &mut Context<Self::Message>,
+            _context: &mut Self::Context,
             message: Self::Message,
         ) -> Result<(), Self::Error> {
             match message {
@@ -233,7 +233,7 @@ mod actors {
 
         fn handle(
             &mut self,
-            _context: &mut Context<Self::Message>,
+            _context: &mut Self::Context,
             message: Self::Message,
         ) -> Result<(), Self::Error> {
             // Add some fake packetization and network latency here
@@ -270,7 +270,7 @@ mod actors {
 
         fn handle(
             &mut self,
-            _context: &mut Context<Self::Message>,
+            _context: &mut Self::Context,
             message: Self::Message,
         ) -> Result<(), Self::Error> {
             match message {
@@ -307,7 +307,7 @@ mod actors {
 
         fn handle(
             &mut self,
-            _context: &mut Context<Self::Message>,
+            _context: &mut Self::Context,
             message: Self::Message,
         ) -> Result<(), Self::Error> {
             match message {
@@ -344,7 +344,7 @@ mod actors {
 
         fn handle(
             &mut self,
-            _context: &mut Context<Self::Message>,
+            _context: &mut Self::Context,
             message: Self::Message,
         ) -> Result<(), Self::Error> {
             match message {
@@ -379,7 +379,7 @@ mod actors {
 
         fn handle(
             &mut self,
-            _context: &mut Context<Self::Message>,
+            _context: &mut Self::Context,
             message: Self::Message,
         ) -> Result<(), Self::Error> {
             match message {
@@ -414,7 +414,7 @@ mod actors {
 
         fn handle(
             &mut self,
-            context: &mut Context<Self::Message>,
+            context: &mut Self::Context,
             message: Self::Message,
         ) -> Result<(), Self::Error> {
             match message {

--- a/examples/simple_timer.rs
+++ b/examples/simple_timer.rs
@@ -27,20 +27,20 @@ impl Actor for TimerExampleActor {
         "TimerExampleActor"
     }
 
-    fn started(&mut self, context: &mut Context<Self::Message>) {
+    fn started(&mut self, context: &mut Self::Context) {
         context.set_deadline(Some(self.started_at + Duration::from_millis(1500)));
     }
 
     fn handle(
         &mut self,
-        _context: &mut Context<Self::Message>,
+        _context: &mut Self::Context,
         message: Self::Message,
     ) -> Result<(), Self::Error> {
         println!("Got a message: {:?} at {:?}", message, self.started_at.elapsed());
         Ok(())
     }
 
-    fn deadline_passed(&mut self, context: &mut Context<Self::Message>, deadline: Instant) {
+    fn deadline_passed(&mut self, context: &mut Self::Context, deadline: Instant) {
         context.myself.send(TimerMessage::Periodic).unwrap();
         context.set_deadline(Some(deadline + Duration::from_secs(1)));
     }

--- a/examples/simple_timer.rs
+++ b/examples/simple_timer.rs
@@ -19,6 +19,7 @@ impl TimerExampleActor {
 }
 
 impl Actor for TimerExampleActor {
+    type Context = Context<Self::Message>;
     type Error = Error;
     type Message = TimerMessage;
 

--- a/examples/simple_timer.rs
+++ b/examples/simple_timer.rs
@@ -40,9 +40,14 @@ impl Actor for TimerExampleActor {
         Ok(())
     }
 
-    fn deadline_passed(&mut self, context: &mut Self::Context, deadline: Instant) {
-        context.myself.send(TimerMessage::Periodic).unwrap();
+    fn deadline_passed(
+        &mut self,
+        context: &mut Self::Context,
+        deadline: Instant,
+    ) -> Result<(), Error> {
+        context.myself.send(TimerMessage::Periodic)?;
         context.set_deadline(Some(deadline + Duration::from_secs(1)));
+        Ok(())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,8 @@ use std::{
     time::{Duration, Instant},
 };
 
+pub mod timed;
+
 #[cfg(test)]
 pub mod testing;
 
@@ -626,6 +628,7 @@ pub trait Actor {
     type Message: Send + 'static;
     /// The type to return on error in the handle method.
     type Error: std::fmt::Debug;
+    /// What kind of context this actor accepts. Usually [`Context<Self::Message>`].
     type Context;
 
     /// The primary function of this trait, allowing an actor to handle incoming messages of a certain type.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //!         "TestActor"
 //!     }
 //!
-//!     fn handle(&mut self, _context: &mut Context<Self::Message>, message: Self::Message) -> Result<(), ()> {
+//!     fn handle(&mut self, _context: &mut Self::Context, message: Self::Message) -> Result<(), ()> {
 //!         println!("message: {}", message);
 //!
 //!         Ok(())
@@ -654,10 +654,10 @@ pub trait Actor {
     /// #    type Error = ();
     /// #    type Message = ();
     /// #    fn name() -> &'static str { "TickingActor" }
-    /// #    fn handle(&mut self, _: &mut Context<Self::Message>, _: ()) -> Result<(), ()> { Ok(()) }
+    /// #    fn handle(&mut self, _: &mut Self::Context, _: ()) -> Result<(), ()> { Ok(()) }
     ///     // ...
     ///
-    ///     fn deadline_passed(&mut self, context: &mut Context<Self::Message>, deadline: Instant) {
+    ///     fn deadline_passed(&mut self, context: &mut Self::Context, deadline: Instant) {
     ///         // do_periodic_housekeeping();
     ///
     ///         // A: Schedule one second from now (even if delayed); drifting tick.
@@ -840,17 +840,17 @@ mod tests {
             "TestActor"
         }
 
-        fn handle(&mut self, _: &mut Context<usize>, message: usize) -> Result<(), ()> {
+        fn handle(&mut self, _: &mut Self::Context, message: usize) -> Result<(), ()> {
             println!("message: {}", message);
 
             Ok(())
         }
 
-        fn started(&mut self, _: &mut Context<usize>) {
+        fn started(&mut self, _: &mut Self::Context) {
             println!("started");
         }
 
-        fn stopped(&mut self, _: &mut Context<usize>) {
+        fn stopped(&mut self, _: &mut Self::Context) {
             println!("stopped");
         }
     }
@@ -899,12 +899,12 @@ mod tests {
                 "LocalActor"
             }
 
-            fn handle(&mut self, _: &mut Context<()>, _: ()) -> Result<(), ()> {
+            fn handle(&mut self, _: &mut Self::Context, _: ()) -> Result<(), ()> {
                 Ok(())
             }
 
             /// We just need this test to compile, not run.
-            fn started(&mut self, ctx: &mut Context<()>) {
+            fn started(&mut self, ctx: &mut Self::Context) {
                 ctx.system_handle.shutdown().unwrap();
             }
         }
@@ -936,11 +936,7 @@ mod tests {
                 "TimeoutActor"
             }
 
-            fn handle(
-                &mut self,
-                ctx: &mut Context<Self::Message>,
-                msg: Self::Message,
-            ) -> Result<(), ()> {
+            fn handle(&mut self, ctx: &mut Self::Context, msg: Self::Message) -> Result<(), ()> {
                 self.handle_count.fetch_add(1, Ordering::SeqCst);
                 if msg.is_some() {
                     ctx.receive_deadline = msg;
@@ -948,7 +944,7 @@ mod tests {
                 Ok(())
             }
 
-            fn deadline_passed(&mut self, _: &mut Context<Self::Message>, _: Instant) {
+            fn deadline_passed(&mut self, _: &mut Self::Context, _: Instant) {
                 self.timeout_count.fetch_add(1, Ordering::SeqCst);
             }
         }

--- a/src/timed.rs
+++ b/src/timed.rs
@@ -1,0 +1,220 @@
+//! Tools to make a given actor able to receive delayed and recurring messages.
+//!
+//! To apply this to a given (receiving) actor:
+//! * Use [`TimedContext<Self::Message>`] as [`Actor::Context`] associated type.
+//!   * Such actors cannot be spawned unless wrapped, making it impossible to forget wrapping it.
+//! * Wrap the actor in [`Timed`] before spawning.
+//!
+//! The wrapped actor will accept [`TimedMessage<M>`] with convenience conversion from `M`.
+//! [`RecipientExt`] becomes available for [`Recipient<TimedMessage<M>>`]s which provides methods like
+//! `send_delayed()`, `send_recurring()`.
+//!
+//! See `delay_actor.rs` example for usage.
+
+use crate::{Actor, Context, Recipient, SendError, SystemHandle};
+use std::{
+    cmp::Ordering,
+    collections::BinaryHeap,
+    ops::Deref,
+    time::{Duration, Instant},
+};
+
+/// A message that can be delivered now, at certain time and optionally repeatedly.
+pub enum TimedMessage<M> {
+    Instant { message: M },
+    Delayed { message: M, fire_at: Instant },
+    Recurring { factory: Box<dyn FnMut() -> M + Send>, fire_at: Instant, interval: Duration },
+}
+
+/// This implementation allows sending direct unwrapped messages to wrapped actors.
+impl<M> From<M> for TimedMessage<M> {
+    fn from(message: M) -> Self {
+        Self::Instant { message }
+    }
+}
+
+/// Convenience methods for [`Recipient`]s that accept [`TimedMessage`]s.
+pub trait RecipientExt<M> {
+    /// Send a `message` now. Convenience to wrap message in [`TimedMessage::Instant`].
+    fn send_now(&self, message: M) -> Result<(), SendError>;
+
+    /// Send a `message` to be delivered later at a certain instant.
+    fn send_timed(&self, message: M, fire_at: Instant) -> Result<(), SendError>;
+
+    /// Send a `message` to be delivered later after some time from now.
+    fn send_delayed(&self, message: M, delay: Duration) -> Result<(), SendError> {
+        self.send_timed(message, Instant::now() + delay)
+    }
+
+    /// Schedule sending of message at `fire_at` plus at regular `interval`s from that point on.
+    fn send_recurring(
+        &self,
+        factory: impl FnMut() -> M + Send + 'static,
+        fire_at: Instant,
+        interval: Duration,
+    ) -> Result<(), SendError>;
+}
+
+impl<M> RecipientExt<M> for Recipient<TimedMessage<M>> {
+    fn send_now(&self, message: M) -> Result<(), SendError> {
+        self.send(TimedMessage::Instant { message })
+    }
+
+    fn send_timed(&self, message: M, fire_at: Instant) -> Result<(), SendError> {
+        self.send(TimedMessage::Delayed { message, fire_at })
+    }
+
+    fn send_recurring(
+        &self,
+        factory: impl FnMut() -> M + Send + 'static,
+        fire_at: Instant,
+        interval: Duration,
+    ) -> Result<(), SendError> {
+        self.send(TimedMessage::Recurring { factory: Box::new(factory), fire_at, interval })
+    }
+}
+
+/// A [`Context`] variant available to actors wrapped by the [`Timed`] actor wrapper.
+pub struct TimedContext<M> {
+    pub system_handle: SystemHandle,
+    pub myself: Recipient<TimedMessage<M>>,
+}
+
+impl<M> TimedContext<M> {
+    fn from_context(context: &Context<TimedMessage<M>>) -> Self {
+        TimedContext {
+            system_handle: context.system_handle.clone(),
+            myself: context.myself.clone(),
+        }
+    }
+}
+
+/// A wrapper around actors to add ability to receive delayed and recurring messages.
+/// See [module documentation](self) for a complete recipe.
+pub struct Timed<A: Actor> {
+    inner: A,
+    queue: BinaryHeap<QueueItem<A::Message>>,
+}
+
+impl<M: Send + 'static, A: Actor<Context = TimedContext<M>, Message = M>> Timed<A> {
+    pub fn new(inner: A) -> Self {
+        Self { inner, queue: Default::default() }
+    }
+
+    fn schedule_timeout(&self, context: &mut <Self as Actor>::Context) {
+        // Schedule next timeout if the queue is not empty.
+        context.set_deadline(self.queue.peek().map(|earliest| earliest.fire_at));
+    }
+}
+
+impl<M: Send + 'static, A: Actor<Context = TimedContext<M>, Message = M>> Actor for Timed<A> {
+    type Context = Context<Self::Message>;
+    type Error = A::Error;
+    type Message = TimedMessage<M>;
+
+    fn handle(
+        &mut self,
+        context: &mut Self::Context,
+        timed_message: Self::Message,
+    ) -> Result<(), Self::Error> {
+        let item = match timed_message {
+            TimedMessage::Instant { message } => {
+                return self.inner.handle(&mut TimedContext::from_context(context), message);
+            },
+            TimedMessage::Delayed { message, fire_at } => {
+                QueueItem { fire_at, payload: Payload::Delayed { message } }
+            },
+            TimedMessage::Recurring { factory, fire_at, interval } => {
+                QueueItem { fire_at, payload: Payload::Recurring { factory, interval } }
+            },
+        };
+
+        self.queue.push(item);
+        self.schedule_timeout(context);
+        Ok(())
+    }
+
+    fn name() -> &'static str {
+        A::name()
+    }
+
+    fn started(&mut self, context: &mut Self::Context) {
+        self.inner.started(&mut TimedContext::from_context(context))
+    }
+
+    fn stopped(&mut self, context: &mut Self::Context) {
+        self.inner.stopped(&mut TimedContext::from_context(context))
+    }
+
+    fn deadline_passed(
+        &mut self,
+        context: &mut Self::Context,
+        _deadline: Instant,
+    ) -> Result<(), Self::Error> {
+        // Handle all messages that should have been handled by now.
+        let now = Instant::now();
+        while self.queue.peek().map(|m| m.fire_at <= now).unwrap_or(false) {
+            let item = self.queue.pop().expect("heap is non-empty, we have just peeked");
+
+            let message = match item.payload {
+                Payload::Delayed { message } => message,
+                Payload::Recurring { mut factory, interval } => {
+                    let message = factory();
+                    self.queue.push(QueueItem {
+                        fire_at: item.fire_at + interval,
+                        payload: Payload::Recurring { factory, interval },
+                    });
+                    message
+                },
+            };
+
+            // Let inner actor do its job.
+            self.inner.handle(&mut TimedContext::from_context(context), message)?;
+        }
+
+        self.schedule_timeout(context);
+        Ok(())
+    }
+}
+
+/// Access wrapped actor.
+impl<A: Actor> Deref for Timed<A> {
+    type Target = A;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+/// Implementation detail, element of message queue ordered by time to fire at.
+struct QueueItem<M> {
+    fire_at: Instant,
+    payload: Payload<M>,
+}
+
+impl<M> PartialEq for QueueItem<M> {
+    fn eq(&self, other: &Self) -> bool {
+        self.fire_at == other.fire_at
+    }
+}
+
+// We cannot derive because that would add too strict bounds.
+impl<M> Eq for QueueItem<M> {}
+
+impl<M> PartialOrd for QueueItem<M> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        // Reverse because [BinaryHeap] is a *max* heap, but we want pop() to return lowest `fire_at`.
+        Some(self.fire_at.cmp(&other.fire_at).reverse())
+    }
+}
+
+impl<M> Ord for QueueItem<M> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.partial_cmp(other).expect("we can always compare")
+    }
+}
+
+enum Payload<M> {
+    Delayed { message: M },
+    Recurring { factory: Box<dyn FnMut() -> M + Send>, interval: Duration },
+}


### PR DESCRIPTION
See module level docs and `delay_actor.rs` example for info.

When actor A wants to send a delayed message to actor B, there are 3 places where the queue can be:
1. in actor (thread) A
2. in some separate actor (thread) C
3. in actor (thread) B.

This PR choses option 3. In our downstream usage, all recurring messages are "to self", so options 1. and 3. are functionally (but not API-wise) equivalent. The chosen approach has some pros and cons:
- pro: modulo the preparatory "independent" core API changes, Timed<> wrapper and friends are strictly separate form the core API (could have been implemented in a separate crate).
- pro: avoids having to pass some `DelayActor` reference around, or having it registered as some global resource.
- pro: delayed messages do not cross thread boundary (in our use-case).
- big con: requires wrapping each delayed-message-receiving actor in the wrapper.
- con: requires ability to customize the `Context` type in actor as a prerequisite.

Closes #14.

Separated into atomic commits, reviewing them individually is suggested. The last commit adds the main functionality, others are prerequisites. I had to tweak core actor API a bit (with changes needing to be done downstream) to be able to provide a nice API of the delayed/recurring functionality.

Demonstration of downstream code changes tonarino/portal#1126, specifically https://github.com/tonarino/portal/pull/1126/commits/4cfefdd45ba2ff7155c6e1943ba90d1bc20c6fe0.