### PR TITLE
RFC: Include intended recipient name in SendError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,20 +97,10 @@ impl std::error::Error for ActorError {}
 /// Failures that can occur when sending a message to an actor.
 #[derive(Debug, Clone, Copy)]
 pub struct SendError {
-    recipient_name: &'static str,
-    reason: SendErrorReason,
-}
-
-impl SendError {
-    /// Get the name of the intended recipient.
-    pub fn recipient_name(&self) -> &'static str {
-        self.recipient_name
-    }
-
-    /// Get the reason why sending has failed.
-    pub fn reason(&self) -> SendErrorReason {
-        self.reason
-    }
+    /// The name of the intended recipient.
+    pub recipient_name: &'static str,
+    /// The reason why sending has failed.
+    pub reason: SendErrorReason,
 }
 
 impl fmt::Display for SendError {
@@ -130,7 +120,8 @@ impl std::error::Error for SendError {}
 /// The actor message channel is disconnected.
 #[derive(Debug, Clone, Copy)]
 pub struct DisconnectedError {
-    recipient_name: &'static str,
+    /// The name of the intended recipient.
+    pub recipient_name: &'static str,
 }
 
 impl fmt::Display for DisconnectedError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -807,7 +807,8 @@ impl<M> Recipient<M> {
 }
 
 pub trait SendResultExt {
-    /// Don't return an `Err` when the recipient is at full capacity, run `func` in such a case instead.
+    /// Don't return an `Err` when the recipient is at full capacity, run `func(receiver_name)`
+    /// in such a case instead. `receiver_name` is the name of the intended recipient.
     fn on_full<F: FnOnce(&'static str)>(self, func: F) -> Result<(), DisconnectedError>;
 
     /// Don't return an `Err` when the recipient is at full capacity.
@@ -1039,6 +1040,7 @@ mod tests {
     fn errors() {
         let mut system = System::new("hi");
         let full_actor = system.prepare(TestActor).with_capacity(0).spawn().unwrap();
+        // Convert to `Recipient` so that we don't keep the receiving side of `Addr` alive.
         let stopped_actor = system.spawn(TestActor).unwrap().recipient();
 
         let error = full_actor.send(123).unwrap_err();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1001,4 +1001,21 @@ mod tests {
 
         system.shutdown().unwrap();
     }
+
+    #[test]
+    fn errors() {
+        let mut system = System::new("hi");
+        let full_actor = system.prepare(TestActor).with_capacity(0).spawn().unwrap();
+        let stopped_actor = system.spawn(TestActor).unwrap().recipient();
+
+        let error = full_actor.send(123).unwrap_err();
+        assert_eq!(error.to_string(), "The channel's capacity is full.");
+        assert_eq!(format!("{:?}", error), "Full");
+
+        system.shutdown().unwrap();
+
+        let error = stopped_actor.send(456usize).unwrap_err();
+        assert_eq!(error.to_string(), "The recipient of the message no longer exists.");
+        assert_eq!(format!("{:?}", error), "Disconnected");
+    }
 }


### PR DESCRIPTION
#### Add test for SendError

We're going to touch it, the tests will demonstrate the changes.

### Include intended recipient name in SendError

This aids with debugging send errors. Thanks to type decoupling made by
`Recipient`, senders may not even know the actual receiving actor, so
senders cannot replicate this behaviour fully on their own.

Should help with debugging downstream issues like tonarino/portal#1153.

Caveats:
- Increases the size of `Recipient`, `Addr`, `SendError` by ~one pointer~ two pointers (one `&str`).
- Introduces API-breaking changes to `SendError` and `SendResultExt::on_full()`.
  - ~Specifically, SendError, DisconnectedError can no longer be constructed by downstream code. That feels correct now, but can be fixed in non-API-breaking manner if needed.~ - no longer true after the last commit.
---

Is it worth it?
