### PR TITLE
For reference: Add Box<dyn fmt::Debug> to SendError, require Actor::Message: Debug

### DIFF
--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -44,9 +44,11 @@ type Chunk = Arc<[Sample; CHUNK_SAMPLES]>;
 const DELAY_CHUNKS: usize = 60;
 
 /// A chunk of samples that represents the "dry" (original, authentic) signal.
+#[derive(Debug)]
 struct DryChunk(Chunk);
 
 /// A chunk of sample that represents the "wet" (processed, edited) signal.
+#[derive(Debug)]
 struct WetChunk(Chunk);
 
 /// DryChunk converts to (unspecified) Chunk (but not the other way around).
@@ -64,6 +66,7 @@ impl From<WetChunk> for Chunk {
 }
 
 /// Dummy trigger for [`Input`] to read next chunk.
+#[derive(Debug)]
 struct ReadNext;
 
 fn silence_chunk() -> Chunk {
@@ -132,6 +135,7 @@ impl Actor for Output {
 }
 
 /// A chunk that knows whether it is dry or wet.
+#[derive(Debug)]
 enum MixerInput {
     /// The original signal.
     Dry(DryChunk),

--- a/examples/media_pipeline.rs
+++ b/examples/media_pipeline.rs
@@ -4,12 +4,14 @@ use env_logger::Env;
 use tonari_actor::{Addr, System, SystemCallbacks};
 
 /// A simplistic representation of a MediaFrame, they just hold frame counters.
+#[derive(Debug)]
 pub enum MediaFrame {
     Video(usize),
     Audio(usize),
 }
 
 /// A simplistic representation of an encoded MediaFrame, they just hold frame counters.
+#[derive(Debug)]
 pub enum EncodedMediaFrame {
     Video(usize),
     Audio(usize),
@@ -22,10 +24,12 @@ mod actors {
     use tonari_actor::{Actor, Context, Recipient};
 
     // Messages
+    #[derive(Debug)]
     pub enum VideoCaptureMessage {
         Capture,
     }
 
+    #[derive(Debug)]
     pub enum AudioCaptureMessage {
         Capture,
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1001,4 +1001,21 @@ mod tests {
 
         system.shutdown().unwrap();
     }
+
+    #[test]
+    fn errors() {
+        let mut system = System::new("hi");
+        let full_actor = system.prepare(TestActor).with_capacity(0).spawn().unwrap();
+        let stopped_actor = system.spawn(TestActor).unwrap().recipient();
+
+        let error = full_actor.send(123).unwrap_err();
+        assert_eq!(error.to_string(), "The channel's capacity is full.");
+        assert_eq!(format!("{:?}", error), "Full");
+
+        system.shutdown().unwrap();
+
+        let error = stopped_actor.send(456usize).unwrap_err();
+        assert_eq!(error.to_string(), "The recipient of the message no longer exists.");
+        assert_eq!(format!("{:?}", error), "Disconnected");
+    }
 }


### PR DESCRIPTION
An alternative to #59, doesn't build.

#### Add test for SendError

We're going to touch it, the tests will demonstrate the changes.

### Add Box<dyn fmt::Debug> to SendError, require Actor::Message: Debug

The problem: does not compile, because popular error libraries like `anyhow`
require the error to be `Sync`. Because we erase the `M` type from SendError,
we either require `M` to be `Sync` or we're not `Sync` at all.

(crosbeam::channel's `TrySendError<M>` doesn't suffer from such a problem,
it is `Sync` when M is `Sync` and vice-versa).