### PR TITLE
Port from crossbeam-channel to flume

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ readme = "README.md"
 keywords = ["actor", "threads"]
 
 [dependencies]
-crossbeam-channel = "0.5"
+# Make sure the eventual-fairness feature is disabled for priority queues.
+flume = { version = "0.10", default-features = false, features = ["select"] }
 log = "0.4"
 parking_lot = "0.11"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -435,13 +435,13 @@ impl System {
                 .recv(&addr.control_rx, |msg| match msg {
                     Ok(control) => Received::Control(control),
                     Err(RecvError::Disconnected) => {
-                        unreachable!("We keep control_tx alive through addr, should no happen.")
+                        panic!("We keep control_tx alive through addr, should not happen.")
                     },
                 })
                 .recv(&addr.message_rx, |msg| match msg {
                     Ok(msg) => Received::Message(msg),
                     Err(RecvError::Disconnected) => {
-                        unreachable!("We keep message_tx alive through addr, should no happen.")
+                        panic!("We keep message_tx alive through addr, should not happen.")
                     },
                 });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,6 +437,15 @@ impl System {
     where
         A: Actor<Context = Context<<A as Actor>::Message>>,
     {
+        /// What can be received during one actor event loop.
+        enum Received<M> {
+            Control(Control),
+            Message(M),
+            Timeout,
+            /// Receiving an error stops the actor thread.
+            Error(ActorError),
+        }
+
         loop {
             // We don't handle the messages (control and actor's) directly in .recv(), that would
             // lead to mutably borrowing actor multiple times. Read into intermediate enum instead.
@@ -528,15 +537,6 @@ impl Deref for System {
     fn deref(&self) -> &Self::Target {
         &self.handle
     }
-}
-
-/// What can be received during one actor event loop.
-enum Received<M> {
-    Control(Control),
-    Message(M),
-    Timeout,
-    /// Receiving an error stops the actor thread.
-    Error(ActorError),
 }
 
 impl SystemHandle {


### PR DESCRIPTION
This is a prerequisite for message priorities #22 - crossbeam has built-in
randomization when receiving messages, while flume lets us control that
using a feature flag.

flume's API is largely the same as crossbeam's, only real difference is
that select() is constructed using builder pattern rather than a macro.

Actor own benchmark result change (crossbeam -> flume):
```
circular/circular (2 actors)
                        time:   [3.0926 ms 3.1223 ms 3.1528 ms]
                        thrpt:  [317.18 Kelem/s 320.28 Kelem/s 323.35 Kelem/s]
                 change:
                        time:   [-24.762% -21.495% -17.992%] (p = 0.00 < 0.05)
                        thrpt:  [+21.940% +27.380% +32.912%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe
circular/circular (native CPU count - 1)
                        time:   [3.9945 ms 4.0224 ms 4.0493 ms]
                        thrpt:  [246.96 Kelem/s 248.61 Kelem/s 250.34 Kelem/s]
                 change:
                        time:   [-7.5891% -5.5178% -3.4030%] (p = 0.00 < 0.05)
                        thrpt:  [+3.5229% +5.8400% +8.2123%]
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low severe
  6 (6.00%) low mild
  3 (3.00%) high mild
circular/circular (native CPU count)
                        time:   [20.821 ms 21.743 ms 22.666 ms]
                        thrpt:  [44.119 Kelem/s 45.993 Kelem/s 48.027 Kelem/s]
                 change:
                        time:   [-16.421% -10.076% -3.3897%] (p = 0.00 < 0.05)
                        thrpt:  [+3.5087% +11.205% +19.648%]
                        Performance has improved.
circular/circular (50 actors)
                        time:   [25.593 ms 27.095 ms 28.638 ms]
                        thrpt:  [34.918 Kelem/s 36.907 Kelem/s 39.073 Kelem/s]
                 change:
                        time:   [-31.525% -24.649% -17.014%] (p = 0.00 < 0.05)
                        thrpt:  [+20.502% +32.712% +46.038%]
                        Performance has improved.
```

That looks good! Measured on my laptop with frequency scaling and thermal
throttling, so there may be some noise.