### PR TITLE
Add high priority message channel for each actor

### DIFF
--- a/examples/actor_wrapping.rs
+++ b/examples/actor_wrapping.rs
@@ -2,7 +2,7 @@ use anyhow::Error;
 use env_logger::Env;
 use log::debug;
 use std::time::{Duration, Instant};
-use tonari_actor::{Actor, Context, System};
+use tonari_actor::{Actor, Context, Priority, System};
 
 /// An actor that wraps any other actor and adds some debug logging around its calls.
 struct LoggingAdapter<A> {
@@ -25,6 +25,10 @@ impl<A: Actor> Actor for LoggingAdapter<A> {
 
     fn name() -> &'static str {
         A::name()
+    }
+
+    fn priority(message: &Self::Message) -> Priority {
+        A::priority(message)
     }
 
     fn started(&mut self, context: &mut Self::Context) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -811,7 +811,7 @@ impl<M> Clone for Recipient<M> {
 }
 
 impl<M> Recipient<M> {
-    /// Send a message to an actor. Returns [`SendError`] if the channel if full; does not block.
+    /// Send a message to an actor. Returns [`SendError`] if the channel is full; does not block.
     /// See [`SendResultExt`] trait for convenient handling of errors.
     pub fn send(&self, message: M) -> Result<(), SendError> {
         self.message_tx


### PR DESCRIPTION
#### Remove Recipient::remaining_capacity()

Would have to accept extra parameter once we add priority channel.
That would be well possible, but perhaps this method in not really needed
once we have prio channels? Let's try without it first.

### Add high priority message channel for each actor

Actor trait has gained new optional method `priority(message: &M)` which
determines priority of each message before being sent.

`Addr` grows by one extra `flume::Receiver`. `Recipient` doesn't grow as its
`message_tx` payload is boxed.

#### Support specifying capacity independently for normal and high-priority channel

When porting portal to use priority channels, I've realized actor systems may
want to set capacity of the normal channel as low as 1 (for actors that cannot
keep up with the pace, but for which that doesn't matter).

Producers of their "bulk" low-priority messages will usually ignore their
channels being full. OTOH producers of their important high-priority messages
may like to fail when their priority channel is full (as ignoring that may
have dire consequences). It would be thus impractical if the priority channel
got similarly small capacity. (actor needs to finish at least one event loop
to get to process the high-prio messages).

#### Forward priority to inner actor in wrapping actors

In the `Timed` wrapper this is non-trivial, so some extra explanation docs
are added.

---
Fixes #22.