### PR TITLE
Allow specifying default capacities on actors themselves

### DIFF
--- a/examples/actor_wrapping.rs
+++ b/examples/actor_wrapping.rs
@@ -14,6 +14,9 @@ impl<A: Actor> Actor for LoggingAdapter<A> {
     type Error = A::Error;
     type Message = A::Message;
 
+    const DEFAULT_CAPACITY_HIGH: usize = A::DEFAULT_CAPACITY_HIGH;
+    const DEFAULT_CAPACITY_NORMAL: usize = A::DEFAULT_CAPACITY_NORMAL;
+
     fn handle(
         &mut self,
         context: &mut Self::Context,

--- a/examples/delay_actor.rs
+++ b/examples/delay_actor.rs
@@ -15,6 +15,8 @@ impl Actor for FinalConsumer {
     type Error = Error;
     type Message = String;
 
+    const DEFAULT_CAPACITY_NORMAL: usize = 6;
+
     fn name() -> &'static str {
         "FinalConsumer"
     }
@@ -33,10 +35,7 @@ fn main() -> Result<(), Error> {
 
     let mut system = System::new("Example Timer System");
 
-    let consumer = system
-        .prepare(Timed::new(FinalConsumer { started_at: Instant::now() }))
-        .with_capacity(6)
-        .spawn()?;
+    let consumer = system.spawn(Timed::new(FinalConsumer { started_at: Instant::now() }))?;
 
     let now = Instant::now();
     consumer.send_recurring(

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -116,6 +116,9 @@ impl Actor for Output {
     type Error = Error;
     type Message = Chunk;
 
+    // Set larger message channel capacity for Output actor for some cushion.
+    const DEFAULT_CAPACITY_NORMAL: usize = 60;
+
     fn name() -> &'static str {
         "Output"
     }
@@ -273,8 +276,7 @@ fn main() -> Result<(), Error> {
     let mut system = System::new("Echo System");
 
     // Start creating actors. Because actors "point forward", start with the last one.
-    // Set larger message channel capacity for Output actor for some cushion.
-    let output_addr = system.prepare(Output).with_capacity(60).spawn()?;
+    let output_addr = system.spawn(Output)?;
 
     // Create Mixer address explicitly in order to break the circular dependency loop.
     let mixer_addr = Addr::default();

--- a/src/timed.rs
+++ b/src/timed.rs
@@ -127,6 +127,9 @@ impl<M: Send + 'static, A: Actor<Context = TimedContext<M>, Message = M>> Actor 
     type Error = A::Error;
     type Message = TimedMessage<M>;
 
+    const DEFAULT_CAPACITY_HIGH: usize = A::DEFAULT_CAPACITY_HIGH;
+    const DEFAULT_CAPACITY_NORMAL: usize = A::DEFAULT_CAPACITY_NORMAL;
+
     fn handle(
         &mut self,
         context: &mut Self::Context,


### PR DESCRIPTION
I'm myself not convinced about this, but publishing for feedback anyway.

Resolves #70 (I apparently forgot about this PR when writing the issue; it even shows that defaults for associated constants are possible/stable).