### PR TITLE
Update criterion and env_logger dev dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ parking_lot = "0.12"
 [dev-dependencies]
 anyhow = "1"
 ctrlc = "3.1"
-criterion = "0.3"
-env_logger = "0.9"
+criterion = "0.4"
+env_logger = "0.10"
 num_cpus = "1"
 
 [[bench]]


### PR DESCRIPTION
Let's be up-to-date before a release. Logs in tests and benches still work.

```
strohel@thicky ~/work/actor $ cargo outdated
All dependencies are up to date, yay!
```

- depends on #73, which should be merged first (for clippy fix)