### PR TITLE
Fix clippy 1.73 lints, update lint configuration

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![warn(clippy::all, clippy::clone_on_ref_ptr)]
+#![warn(clippy::clone_on_ref_ptr, clippy::todo)]
 
 //! This crate aims to provide a minimalist and high-performance actor framework
 //! for Rust with significantly less complexity than other frameworks like

--- a/src/timed.rs
+++ b/src/timed.rs
@@ -251,14 +251,14 @@ impl<M> Eq for QueueItem<M> {}
 
 impl<M> PartialOrd for QueueItem<M> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        // Reverse because [BinaryHeap] is a *max* heap, but we want pop() to return lowest `fire_at`.
-        Some(self.fire_at.cmp(&other.fire_at).reverse())
+        Some(self.cmp(other))
     }
 }
 
 impl<M> Ord for QueueItem<M> {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.partial_cmp(other).expect("we can always compare")
+        // Reverse because [BinaryHeap] is a *max* heap, but we want pop() to return lowest `fire_at`.
+        self.fire_at.cmp(&other.fire_at).reverse()
     }
 }
 


### PR DESCRIPTION
#### timed::QueueItem: Implement partial_cmp() using cmp(), not the other way around

Fixes clippy 1.73 lint.

This different order makes sense, as it avoids an expect().

#### Clippy lints update: `all` is implied, add `todo`

I must have been mistaken when originally introducing `clippy:all`, because these are, by definition, lints that are enabled without any configuration: https://doc.rust-lang.org/stable/clippy/usage.html#lint-configuration

Add a lint that catches `todo!()` (but allows `panic!()`, `unreachable!()`, `unimplemented!()`) - you're encouraged to use it during development as a reminder for stuff to finish before a change can be merged.