### PR TITLE
Missing address warning

### DIFF
--- a/benches/pub_sub.rs
+++ b/benches/pub_sub.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, Instant};
 use tonari_actor::{Actor, Context, Event, Recipient, System};
 
 #[derive(Debug, Clone)]
-struct StringEvent(String);
+struct StringEvent(());
 
 impl Event for StringEvent {}
 
@@ -45,7 +45,7 @@ impl Actor for PublisherActor {
             PublisherMessage::PublishEvents => {
                 let start = Instant::now();
                 for _i in 0..self.iterations {
-                    context.system_handle.publish(StringEvent("hello".to_string()))?;
+                    context.system_handle.publish(StringEvent(()))?;
                 }
                 let elapsed = start.elapsed();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1037,7 +1037,6 @@ impl<M: Into<N>, N> SenderTrait<M> for Arc<dyn SenderTrait<N>> {
 #[cfg(test)]
 mod tests {
     use std::{
-        rc::Rc,
         sync::atomic::{AtomicU32, Ordering},
         time::Duration,
     };
@@ -1103,7 +1102,7 @@ mod tests {
     #[test]
     fn send_constraints() {
         #[derive(Default)]
-        struct LocalActor(Rc<()>);
+        struct LocalActor(());
         impl Actor for LocalActor {
             type Context = Context<Self::Message>;
             type Error = ();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,7 +353,11 @@ impl<'a, A: 'static + Actor<Context = Context<<A as Actor>::Message>>, F: FnOnce
     pub fn run_and_block(self) -> Result<(), ActorError> {
         let factory = self.factory;
         let capacity = self.capacity;
-        let addr = self.addr.unwrap_or_else(|| Addr::with_capacity(capacity));
+        let addr = self.addr.unwrap_or_else(|| {
+            warn!("Actor {} does not have an assigned address, creating an address with capacity {}",
+                A::name(), capacity);
+            Addr::with_capacity(capacity)
+        });
 
         self.system.block_on(factory(), addr)
     }
@@ -369,7 +373,11 @@ impl<
     pub fn spawn(self) -> Result<Addr<A>, ActorError> {
         let factory = self.factory;
         let capacity = self.capacity;
-        let addr = self.addr.unwrap_or_else(|| Addr::with_capacity(capacity));
+        let addr = self.addr.unwrap_or_else(|| {
+            warn!("Actor {} does not have an assigned address; creating an address with capacity {}",
+                A::name(), capacity);
+            Addr::with_capacity(capacity)
+        });
 
         self.system.spawn_fn_with_addr(factory, addr.clone()).map(move |_| addr)
     }


### PR DESCRIPTION
This PR adds a warning when a `SpawnBuilder` is used without an address and with a default capacity. Such usage is often erroneous and it's hard to debug why such an actor is not receiving messages coming to an unassigned address.

Alternatives:
* It might be preferable to make this situation a hard error (ideally at compile-time) but I wasn't sure whether we want that.
* Another possibility is to add a warning on the sending side, if an address wasn't connected to an actor.

The other changes in this PR are fixing clippy.