### PR TITLE
Cache last published event

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ keywords = ["actor", "threads"]
 flume = { version = "0.10", default-features = false, features = ["select"] }
 log = "0.4"
 parking_lot = "0.12"
-dashmap = "6"
 
 [dev-dependencies]
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ keywords = ["actor", "threads"]
 flume = { version = "0.10", default-features = false, features = ["select"] }
 log = "0.4"
 parking_lot = "0.12"
+dashmap = "6"
 
 [dev-dependencies]
 anyhow = "1"

--- a/benches/pub_sub.rs
+++ b/benches/pub_sub.rs
@@ -4,7 +4,7 @@ use std::{
     hint::black_box,
     time::{Duration, Instant},
 };
-use tonari_actor::{Actor, CacheableEvent, Context, Event, Recipient, System};
+use tonari_actor::{Actor, Context, Event, Recipient, System};
 
 const PAYLOAD: &str = "This is the payload that will be used in the test event. It should be of \
                        reasonable size for a representative event, which is hard to determine. \
@@ -12,11 +12,8 @@ const PAYLOAD: &str = "This is the payload that will be used in the test event. 
 
 #[derive(Debug, Clone)]
 struct StringEvent(String);
-impl Event for StringEvent {}
 
-#[derive(Debug, Clone)]
-struct CacheableStringEvent(String);
-impl CacheableEvent for CacheableStringEvent {}
+impl Event for StringEvent {}
 
 enum PublisherMessage {
     SubscriberStarted,
@@ -24,14 +21,13 @@ enum PublisherMessage {
 }
 
 #[derive(Clone)]
-struct PublisherActor<E> {
-    event: E,
+struct PublisherActor {
     subscriber_count: usize,
     iterations: u64,
     result_sender: flume::Sender<Duration>,
 }
 
-impl<E: Event> Actor for PublisherActor<E> {
+impl Actor for PublisherActor {
     type Context = Context<Self::Message>;
     type Error = Error;
     type Message = PublisherMessage;
@@ -56,7 +52,7 @@ impl<E: Event> Actor for PublisherActor<E> {
             PublisherMessage::PublishEvents => {
                 let start = Instant::now();
                 for _i in 0..self.iterations {
-                    context.system_handle.publish(self.event.clone())?;
+                    context.system_handle.publish(StringEvent(PAYLOAD.to_string()))?;
                 }
                 let elapsed = start.elapsed();
 
@@ -81,7 +77,7 @@ impl SubscriberActor {
 impl Actor for SubscriberActor {
     type Context = Context<Self::Message>;
     type Error = Error;
-    type Message = EitherEvent;
+    type Message = StringEvent;
 
     fn name() -> &'static str {
         "SubscriberActor"
@@ -89,7 +85,6 @@ impl Actor for SubscriberActor {
 
     fn started(&mut self, context: &mut Self::Context) {
         context.subscribe::<StringEvent>();
-        context.subscribe::<CacheableStringEvent>();
         for publisher_addr in self.publisher_addrs.iter() {
             publisher_addr.send(PublisherMessage::SubscriberStarted).unwrap();
         }
@@ -101,43 +96,12 @@ impl Actor for SubscriberActor {
         message: Self::Message,
     ) -> Result<(), Self::Error> {
         // This black_box has a nice side effect that it silences the 'field is never read' warning.
-        black_box(message.payload());
+        black_box(message.0);
         Ok(())
     }
 }
 
-enum EitherEvent {
-    Base(StringEvent),
-    Cacheable(CacheableStringEvent),
-}
-
-impl EitherEvent {
-    fn payload(self) -> String {
-        match self {
-            EitherEvent::Base(StringEvent(payload))
-            | EitherEvent::Cacheable(CacheableStringEvent(payload)) => payload,
-        }
-    }
-}
-
-impl From<StringEvent> for EitherEvent {
-    fn from(value: StringEvent) -> Self {
-        Self::Base(value)
-    }
-}
-
-impl From<CacheableStringEvent> for EitherEvent {
-    fn from(value: CacheableStringEvent) -> Self {
-        Self::Cacheable(value)
-    }
-}
-
-fn run_pubsub_system<E: Event + Send>(
-    event: E,
-    publishers: usize,
-    subscribers: usize,
-    iterations: u64,
-) -> Duration {
+fn run_pubsub_system(publishers: usize, subscribers: usize, iterations: u64) -> Duration {
     let mut system = System::new("pub sub bench");
     let (result_sender, result_receiver) = flume::bounded(publishers);
 
@@ -145,7 +109,6 @@ fn run_pubsub_system<E: Event + Send>(
     let per_publisher_iterations = iterations / publishers as u64;
     let publisher_actors = vec![
         PublisherActor {
-            event,
             subscriber_count: subscribers,
             iterations: per_publisher_iterations,
             result_sender
@@ -187,33 +150,11 @@ fn criterion_benchmark(c: &mut Criterion) {
                 format!("{publishers} publishers {subscribers} subscribers"),
                 |b| {
                     b.iter_custom(|iterations| {
-                        run_pubsub_system(
-                            StringEvent(PAYLOAD.to_string()),
-                            publishers,
-                            subscribers,
-                            iterations,
-                        )
+                        run_pubsub_system(publishers, subscribers, iterations)
                     })
                 },
             );
         }
-    }
-
-    let subscribers = 10;
-    for publishers in [1, 2] {
-        group.bench_function(
-            format!("{publishers} publishers {subscribers} subscribers (cacheable event type)"),
-            |b| {
-                b.iter_custom(|iterations| {
-                    run_pubsub_system(
-                        CacheableStringEvent(PAYLOAD.to_string()),
-                        publishers,
-                        subscribers,
-                        iterations,
-                    )
-                })
-            },
-        );
     }
 }
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,5 @@
-use_small_heuristics="Max"
+format_strings = true
+use_small_heuristics = "Max"
 imports_granularity = "Crate"
 match_block_trailing_comma = true
 reorder_impl_items = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,6 +315,9 @@ impl<M> Context<M> {
     ///
     /// Note that subscribing twice to the same event would result in duplicate events -- no
     /// de-duplication of subscriptions is performed.
+    ///
+    /// This method may fail if it is not possible to send the latest event. In this case it is
+    /// guaranteed that the subscription did not take place. You can safely try again.
     pub fn subscribe_and_receive_latest<E: Event + Into<M>>(&self) -> Result<(), SendError>
     where
         M: 'static,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,11 +226,14 @@ enum SystemState {
 
 /// A marker trait for types which participate in the publish-subscribe system
 /// of the actor framework.
-pub trait Event: Clone + std::any::Any + 'static {}
+pub trait Event: Clone + std::any::Any + 'static + Send + Sync {}
 
 #[derive(Default)]
 struct EventSubscribers {
     events: HashMap<TypeId, Vec<EventCallback>>,
+    /// We cache the last published value of each event type.
+    /// Subscribers can request to receive it upon subscription.
+    last_value_cache: HashMap<TypeId, Box<dyn std::any::Any + Send + Sync>>,
 }
 
 /// Contains the "metadata" of the system, including information about the registry
@@ -289,6 +292,19 @@ impl<M> Context<M> {
         M: 'static,
     {
         self.system_handle.subscribe_recipient::<M, E>(self.myself.clone());
+    }
+
+    /// Subscribe current actor to event of type `E` and send the last cached event to it.
+    /// This is part of the event system. You don't need to call this method to receive
+    /// direct messages sent using [`Addr`] and [`Recipient`].
+    ///
+    /// Note that subscribing twice to the same event would result in duplicate events -- no
+    /// de-duplication of subscriptions is performed.
+    pub fn subscribe_and_receive_latest<E: Event + Into<M>>(&self) -> Result<(), SendError>
+    where
+        M: 'static,
+    {
+        self.system_handle.subscribe_and_receive_latest::<M, E>(self.myself.clone())
     }
 }
 
@@ -728,13 +744,51 @@ impl SystemHandle {
         }));
     }
 
+    /// Subscribe given `recipient` to events of type `E` and send the last cached event to it.
+    /// See [`Context::subscribe_and_receive_latest()`].
+    pub fn subscribe_and_receive_latest<M: 'static, E: Event + Into<M>>(
+        &self,
+        recipient: Recipient<M>,
+    ) -> Result<(), SendError> {
+        let mut event_subscribers = self.event_subscribers.write();
+
+        // Send the last cached value if there is one.
+        if let Some(last_cached_value) = event_subscribers.last_value_cache.get(&TypeId::of::<E>())
+        {
+            if let Some(msg) = last_cached_value.downcast_ref::<E>() {
+                recipient.send(msg.clone().into())?;
+            }
+        }
+
+        // Duplicate the contents of Self::subscribe_recipient() to reuse the same WriteGuard
+        // for better performance.
+        let subs = event_subscribers.events.entry(TypeId::of::<E>()).or_default();
+        subs.push(Box::new(move |e| {
+            if let Some(event) = e.downcast_ref::<E>() {
+                let msg = event.clone();
+                recipient.send(msg.into())?;
+            }
+
+            Ok(())
+        }));
+
+        Ok(())
+    }
+
     /// Publish an event. All actors that have previously subscribed to the type will receive it.
+    ///
+    /// The event will be also cached. Actors that will subscribe to the type in future may choose
+    /// to receive the last cached event upon subscription.
     ///
     /// When sending to some subscriber fails, others are still tried and vec of errors is returned.
     /// For direct, non-[`Clone`] or high-throughput messages please use [`Addr`] or [`Recipient`].
     pub fn publish<E: Event>(&self, event: E) -> Result<(), PublishError> {
-        let event_subscribers = self.event_subscribers.read();
-        if let Some(subs) = event_subscribers.events.get(&TypeId::of::<E>()) {
+        let mut event_subscribers = self.event_subscribers.write();
+        let type_id = TypeId::of::<E>();
+
+        event_subscribers.last_value_cache.insert(type_id, Box::new(event.clone()));
+
+        if let Some(subs) = event_subscribers.events.get(&type_id) {
             let errors: Vec<SendError> = subs
                 .iter()
                 .filter_map(|subscriber_callback| subscriber_callback(&event).err())
@@ -1291,5 +1345,47 @@ mod tests {
             *received.lock(),
             [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         );
+    }
+
+    #[test]
+    fn last_cached_event() {
+        impl Event for () {}
+
+        struct Subscriber;
+        impl Actor for Subscriber {
+            type Context = Context<Self::Message>;
+            type Error = ();
+            type Message = ();
+
+            fn started(&mut self, context: &mut Self::Context) {
+                context
+                    .subscribe_and_receive_latest::<Self::Message>()
+                    .expect("can receive last cached value");
+            }
+
+            fn handle(
+                &mut self,
+                context: &mut Self::Context,
+                _: Self::Message,
+            ) -> Result<(), Self::Error> {
+                println!("Event received!");
+                context.system_handle.shutdown().unwrap();
+                Ok(())
+            }
+
+            fn name() -> &'static str {
+                "recipient"
+            }
+        }
+
+        let mut system = System::new("last cached event");
+        system.publish(()).expect("can publish event");
+
+        // This test will block indefinitely if the event isn't delivered.
+        system
+            .prepare(Subscriber)
+            .with_addr(Addr::with_capacity(1))
+            .run_and_block()
+            .expect("actor finishes successfully");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,7 +233,7 @@ struct EventSubscribers {
     events: HashMap<TypeId, Vec<EventCallback>>,
     /// We cache the last published value of each event type.
     /// Subscribers can request to receive it upon subscription.
-    last_value_cache: HashMap<TypeId, Box<dyn std::any::Any + Send + Sync>>,
+    last_value_cache: dashmap::DashMap<TypeId, Box<dyn std::any::Any + Send + Sync>>,
 }
 
 /// Contains the "metadata" of the system, including information about the registry
@@ -783,7 +783,7 @@ impl SystemHandle {
     /// When sending to some subscriber fails, others are still tried and vec of errors is returned.
     /// For direct, non-[`Clone`] or high-throughput messages please use [`Addr`] or [`Recipient`].
     pub fn publish<E: Event>(&self, event: E) -> Result<(), PublishError> {
-        let mut event_subscribers = self.event_subscribers.write();
+        let event_subscribers = self.event_subscribers.read();
         let type_id = TypeId::of::<E>();
 
         event_subscribers.last_value_cache.insert(type_id, Box::new(event.clone()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -322,7 +322,8 @@ impl From<usize> for Capacity {
 /// A builder for configuring [`Actor`] spawning.
 /// You can specify your own [`Addr`] for the Actor, or let the system create
 /// a new address with either provided or default capacity.
-#[must_use = "You must call .with_addr(), .with_capacity(), or .with_default_capacity() to configure this builder"]
+#[must_use = "You must call .with_addr(), .with_capacity(), or .with_default_capacity() to \
+              configure this builder"]
 pub struct SpawnBuilderWithoutAddress<'a, A: Actor, F: FnOnce() -> A> {
     system: &'a mut System,
     factory: F,
@@ -631,7 +632,11 @@ impl SystemHandle {
 
             match *system_state_lock {
                 SystemState::ShuttingDown | SystemState::Stopped => {
-                    debug!("Thread [{}] called system.shutdown() but the system is already shutting down or stopped", current_thread_name);
+                    debug!(
+                        "Thread [{}] called system.shutdown() but the system is already shutting \
+                         down or stopped",
+                        current_thread_name
+                    );
                     return Ok(());
                 },
                 SystemState::Running => {

--- a/src/timed.rs
+++ b/src/timed.rs
@@ -16,7 +16,7 @@
 //!
 //! See `delay_actor.rs` example for usage.
 
-use crate::{Actor, CacheableEvent, Context, Event, Priority, Recipient, SendError, SystemHandle};
+use crate::{Actor, Context, Event, Priority, Recipient, SendError, SystemHandle};
 use std::{
     cmp::Ordering,
     collections::BinaryHeap,
@@ -106,7 +106,7 @@ impl<M> TimedContext<M> {
     /// Subscribe current actor to event of type `E` and send the last cached event to it.
     /// Events will be delivered as instant messages.
     /// See [`crate::Context::subscribe()`].
-    pub fn subscribe_and_receive_latest<E: CacheableEvent + Into<M>>(&self) -> Result<(), SendError>
+    pub fn subscribe_and_receive_latest<E: Event + Into<M>>(&self) -> Result<(), SendError>
     where
         M: 'static,
     {

--- a/src/timed.rs
+++ b/src/timed.rs
@@ -16,7 +16,7 @@
 //!
 //! See `delay_actor.rs` example for usage.
 
-use crate::{Actor, Context, Event, Priority, Recipient, SendError, SystemHandle};
+use crate::{Actor, CacheableEvent, Context, Event, Priority, Recipient, SendError, SystemHandle};
 use std::{
     cmp::Ordering,
     collections::BinaryHeap,
@@ -106,7 +106,7 @@ impl<M> TimedContext<M> {
     /// Subscribe current actor to event of type `E` and send the last cached event to it.
     /// Events will be delivered as instant messages.
     /// See [`crate::Context::subscribe()`].
-    pub fn subscribe_and_receive_latest<E: Event + Into<M>>(&self) -> Result<(), SendError>
+    pub fn subscribe_and_receive_latest<E: CacheableEvent + Into<M>>(&self) -> Result<(), SendError>
     where
         M: 'static,
     {

--- a/src/timed.rs
+++ b/src/timed.rs
@@ -102,6 +102,16 @@ impl<M> TimedContext<M> {
         // The recipient() call allows conversion from M to TimedMessage<M>.
         self.system_handle.subscribe_recipient::<M, E>(self.myself.recipient());
     }
+
+    /// Subscribe current actor to event of type `E` and send the last cached event to it.
+    /// Events will be delivered as instant messages.
+    /// See [`crate::Context::subscribe()`].
+    pub fn subscribe_and_receive_latest<E: Event + Into<M>>(&self) -> Result<(), SendError>
+    where
+        M: 'static,
+    {
+        self.system_handle.subscribe_and_receive_latest::<M, E>(self.myself.recipient())
+    }
 }
 
 /// A wrapper around actors to add ability to receive delayed and recurring messages.


### PR DESCRIPTION
and let subscribers receive it upon subscription.

Optionally, we could provide a separate marker trait for cached events and persist only those. I couldn't figure out how to dynamically query for the type (trait) in `publish`. Somehow `downcast_ref` is not implemented for `Event` (despite `Event` being `Any`). I'd appreciate some help with that.

This causes performance regression for the pub-sub system. Here's output of `cargo bench --bench pub_sub` running on this branch (comparing it to the previous run on `main`):

<details><summary>Details</summary>
<p>

```
   Compiling tonari-actor v0.9.0 (/Users/jentak/workspace/tonari/actor)
    Finished `bench` profile [optimized] target(s) in 1.20s
     Running benches/pub_sub.rs (target/release/deps/pub_sub-9cceefaff682ce83)
publish/1 publishers 10 subscribers
                        time:   [2.3908 µs 2.8514 µs 3.4074 µs]
                        thrpt:  [293.48 Kelem/s 350.71 Kelem/s 418.27 Kelem/s]
                 change:
                        time:   [+23.719% +56.164% +97.912%] (p = 0.00 < 0.05)
                        thrpt:  [-49.473% -35.965% -19.171%]
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
publish/2 publishers 10 subscribers
                        time:   [3.5475 µs 3.9570 µs 4.4083 µs]
                        thrpt:  [226.84 Kelem/s 252.71 Kelem/s 281.89 Kelem/s]
                 change:
                        time:   [+95.062% +134.00% +177.48%] (p = 0.00 < 0.05)
                        thrpt:  [-63.962% -57.265% -48.734%]
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe
publish/10 publishers 10 subscribers
                        time:   [27.460 µs 30.042 µs 32.920 µs]
                        thrpt:  [30.377 Kelem/s 33.287 Kelem/s 36.416 Kelem/s]
                 change:
                        time:   [+84.814% +102.23% +121.67%] (p = 0.00 < 0.05)
                        thrpt:  [-54.888% -50.552% -45.891%]
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
publish/1 publishers 100 subscribers
                        time:   [75.190 µs 81.870 µs 87.810 µs]
                        thrpt:  [11.388 Kelem/s 12.214 Kelem/s 13.300 Kelem/s]
                 change:
                        time:   [-10.861% -5.4355% -0.4260%] (p = 0.03 < 0.05)
                        thrpt:  [+0.4278% +5.7480% +12.184%]
                        Change within noise threshold.
Found 11 outliers among 100 measurements (11.00%)
  8 (8.00%) low severe
  1 (1.00%) low mild
  2 (2.00%) high severe
publish/2 publishers 100 subscribers
                        time:   [79.105 µs 97.231 µs 115.16 µs]
                        thrpt:  [8.6836 Kelem/s 10.285 Kelem/s 12.641 Kelem/s]
                 change:
                        time:   [-15.101% -0.2671% +14.740%] (p = 0.97 > 0.05)
                        thrpt:  [-12.846% +0.2678% +17.787%]
                        No change in performance detected.
publish/10 publishers 100 subscribers
                        time:   [774.46 µs 781.99 µs 788.91 µs]
                        thrpt:  [1.2676 Kelem/s 1.2788 Kelem/s 1.2912 Kelem/s]
                 change:
                        time:   [+299.05% +448.33% +691.39%] (p = 0.00 < 0.05)
                        thrpt:  [-87.364% -81.763% -74.941%]
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low severe
  5 (5.00%) low mild
```

</p>
</details> 


That's likely caused by the contention on `SystemHandle::event_subscribers` RwLock. Previously it only needed exclusive access when subscribing and shared access when publishing. Now it needs exclusive access when subscribing *and* publishing.

Closes https://github.com/tonarino/actor/issues/86

This is a semver-breaking change (due to the new bounds on Event).