### PR TITLE
Error reporting QoL

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -8,7 +8,7 @@ struct ChainLink {
 
 impl Actor for ChainLink {
     type Context = Context<Self::Message>;
-    type Error = ();
+    type Error = String;
     type Message = u64;
 
     fn name() -> &'static str {

--- a/src/timed.rs
+++ b/src/timed.rs
@@ -292,14 +292,14 @@ mod tests {
 
     impl Actor for TimedTestActor {
         type Context = TimedContext<Self::Message>;
-        type Error = ();
+        type Error = String;
         type Message = usize;
 
         fn name() -> &'static str {
             "TimedTestActor"
         }
 
-        fn handle(&mut self, context: &mut Self::Context, message: usize) -> Result<(), ()> {
+        fn handle(&mut self, context: &mut Self::Context, message: usize) -> Result<(), String> {
             {
                 let mut guard = self.received.lock().unwrap();
                 guard.push(message);


### PR DESCRIPTION
- require Display instead of Debug for Actor::Error associated type
- print handle() (and friends) errors using `{:#}` rather than `{:?}`
  - this hides the backtrace print of anyhow errors
- differentiate handle() (and friends) errors while shutting down vs. running and log them with lower severity
- make it more clear and less spammy when trying to shut down a system while it is already shutting down

This is a semver-breaking change (due to the new bound on Actor::Error).