### PR TITLE
Make `Actor::started()`, `stopped()` fallible

### DIFF
--- a/examples/pub_sub_example.rs
+++ b/examples/pub_sub_example.rs
@@ -1,4 +1,4 @@
-use anyhow::Error;
+use anyhow::{Error, Result};
 use env_logger::Env;
 use std::time::{Duration, Instant};
 use tonari_actor::{Actor, Context, Event, System};
@@ -40,9 +40,10 @@ impl Actor for PublisherActor {
         "PublisherActor"
     }
 
-    fn started(&mut self, context: &mut Self::Context) {
+    fn started(&mut self, context: &mut Self::Context) -> Result<()> {
         context.set_deadline(Some(self.started_at + Duration::from_millis(1500)));
         context.subscribe::<StringEvent>();
+        Ok(())
     }
 
     fn handle(
@@ -71,11 +72,7 @@ impl Actor for PublisherActor {
         Ok(())
     }
 
-    fn deadline_passed(
-        &mut self,
-        context: &mut Self::Context,
-        deadline: Instant,
-    ) -> Result<(), Error> {
+    fn deadline_passed(&mut self, context: &mut Self::Context, deadline: Instant) -> Result<()> {
         context.myself.send(PublisherMessage::Periodic)?;
         context.set_deadline(Some(deadline + Duration::from_secs(1)));
         Ok(())
@@ -104,15 +101,12 @@ impl Actor for SubscriberActor1 {
         "SubscriberActor1"
     }
 
-    fn started(&mut self, context: &mut Self::Context) {
+    fn started(&mut self, context: &mut Self::Context) -> Result<()> {
         context.subscribe::<StringEvent>();
+        Ok(())
     }
 
-    fn handle(
-        &mut self,
-        _context: &mut Self::Context,
-        message: Self::Message,
-    ) -> Result<(), Self::Error> {
+    fn handle(&mut self, _context: &mut Self::Context, message: Self::Message) -> Result<()> {
         match message {
             SubscriberMessage::Text(text) => {
                 println!("SubscriberActor1 got a text message: {:?}", text);
@@ -132,15 +126,12 @@ impl Actor for SubscriberActor2 {
         "SubscriberActor1"
     }
 
-    fn started(&mut self, context: &mut Self::Context) {
+    fn started(&mut self, context: &mut Self::Context) -> Result<()> {
         context.subscribe::<StringEvent>();
+        Ok(())
     }
 
-    fn handle(
-        &mut self,
-        _context: &mut Self::Context,
-        message: Self::Message,
-    ) -> Result<(), Self::Error> {
+    fn handle(&mut self, _context: &mut Self::Context, message: Self::Message) -> Result<()> {
         match message {
             SubscriberMessage::Text(text) => {
                 println!("SubscriberActor2 got a text message: {:?}", text);

--- a/examples/simple_timer.rs
+++ b/examples/simple_timer.rs
@@ -1,4 +1,4 @@
-use anyhow::Error;
+use anyhow::{Error, Result};
 use env_logger::Env;
 use std::time::{Duration, Instant};
 use tonari_actor::{Actor, Context, System};
@@ -27,24 +27,17 @@ impl Actor for TimerExampleActor {
         "TimerExampleActor"
     }
 
-    fn started(&mut self, context: &mut Self::Context) {
+    fn started(&mut self, context: &mut Self::Context) -> Result<()> {
         context.set_deadline(Some(self.started_at + Duration::from_millis(1500)));
+        Ok(())
     }
 
-    fn handle(
-        &mut self,
-        _context: &mut Self::Context,
-        message: Self::Message,
-    ) -> Result<(), Self::Error> {
+    fn handle(&mut self, _context: &mut Self::Context, message: Self::Message) -> Result<()> {
         println!("Got a message: {:?} at {:?}", message, self.started_at.elapsed());
         Ok(())
     }
 
-    fn deadline_passed(
-        &mut self,
-        context: &mut Self::Context,
-        deadline: Instant,
-    ) -> Result<(), Error> {
+    fn deadline_passed(&mut self, context: &mut Self::Context, deadline: Instant) -> Result<()> {
         context.myself.send(TimerMessage::Periodic)?;
         context.set_deadline(Some(deadline + Duration::from_secs(1)));
         Ok(())

--- a/src/timed.rs
+++ b/src/timed.rs
@@ -216,11 +216,11 @@ impl<M: Send + 'static, A: Actor<Context = TimedContext<M>, Message = M>> Actor 
         }
     }
 
-    fn started(&mut self, context: &mut Self::Context) {
+    fn started(&mut self, context: &mut Self::Context) -> Result<(), Self::Error> {
         self.inner.started(&mut TimedContext::from_context(context))
     }
 
-    fn stopped(&mut self, context: &mut Self::Context) {
+    fn stopped(&mut self, context: &mut Self::Context) -> Result<(), Self::Error> {
         self.inner.stopped(&mut TimedContext::from_context(context))
     }
 
@@ -314,7 +314,7 @@ mod tests {
             Ok(())
         }
 
-        fn started(&mut self, context: &mut Self::Context) {
+        fn started(&mut self, context: &mut Self::Context) -> Result<(), String> {
             context
                 .myself
                 .send_recurring(
@@ -322,7 +322,7 @@ mod tests {
                     Instant::now() + Duration::from_millis(50),
                     Duration::from_millis(100),
                 )
-                .unwrap()
+                .map_err(|e| e.to_string())
         }
     }
 


### PR DESCRIPTION
- on top of #88

I've long time wanted to do this, other work on actor has finally triggered me.

This should allow removing almost all remaining occurrences of fallible `.unwrap()` / `.expect()` in our downstream code.

It is (obviously) semver-breaking change which causes a bit of churn to adapt to, but the fact of adapting itself should be a nice cleanup.