### PR TITLE
Fix docs build on docs.rs (hopefully), add Docs CI

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -7,7 +7,7 @@ jobs:
     name: Cargo Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -7,7 +7,7 @@ jobs:
     name: Cargo Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,13 +1,13 @@
 on: [push, pull_request]
 
-name: Cargo Test
+name: Cargo Test & Docs
 
 jobs:
   test:
     name: Cargo Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -17,3 +17,14 @@ jobs:
         with:
           command: test
           args: --all-features
+
+  doc:
+    name: Documentation
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -Dwarnings
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/install@cargo-docs-rs
+      - run: cargo docs-rs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["actor", "threads"]
 [package.metadata.docs.rs]
 # Document with all features enabled.
 all-features = true
+rustc-args = ["--cfg", "tokio_unstable"]
 
 [features]
 default = []


### PR DESCRIPTION
We got a failure on docs.rs with 0.12, better catch this earlier: https://docs.rs/crate/tonari-actor/latest/builds/2868173

First commit adds a CI per https://github.com/dtolnay/cargo-docs-rs - but it doesn't fail.

Second commit should fix the build, but hard to tell before publishing.